### PR TITLE
Add proximity search and enhanced filters

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,9 @@
 @import "tailwindcss";
 
+button:not(:disabled) {
+  cursor: pointer;
+}
+
 /* Prevent Leaflet map from overlapping Tailwind UI elements */
 .leaflet-container {
   z-index: 0;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,8 +8,10 @@ import TableView from '@/components/table/TableView'
 
 const DEFAULT_FILTERS: FilterState = {
   search: '',
+  schoolTypes: [],
   schoolLevels: [],
   starRatings: [],
+  proximity: null,
 }
 
 export default function Home() {

--- a/src/components/filters/FilterControls.tsx
+++ b/src/components/filters/FilterControls.tsx
@@ -1,8 +1,10 @@
 'use client'
 
-import type { FilterState, SchoolLevel, StarRating } from '@/types/school'
+import type { FilterState, SchoolType, SchoolLevel, StarRating } from '@/types/school'
 import { getMarkerColor } from '@/utils/markerColors'
+import ProximitySearch from './ProximitySearch'
 
+const ALL_TYPES: SchoolType[] = ['Regular', 'Charter']
 const ALL_LEVELS: SchoolLevel[] = ['Elementary', 'Middle', 'High']
 const ALL_STARS: StarRating[] = [1, 2, 3, 4, 5]
 
@@ -14,8 +16,17 @@ interface FilterControlsProps {
 export default function FilterControls({ filters, onChange }: FilterControlsProps) {
   const hasActive =
     filters.search !== '' ||
+    filters.schoolTypes.length > 0 ||
     filters.schoolLevels.length > 0 ||
-    filters.starRatings.length > 0
+    filters.starRatings.length > 0 ||
+    filters.proximity !== null
+
+  function toggleType(type: SchoolType) {
+    const next = filters.schoolTypes.includes(type)
+      ? filters.schoolTypes.filter((t) => t !== type)
+      : [...filters.schoolTypes, type]
+    onChange({ ...filters, schoolTypes: next })
+  }
 
   function toggleLevel(level: SchoolLevel) {
     const next = filters.schoolLevels.includes(level)
@@ -32,19 +43,25 @@ export default function FilterControls({ filters, onChange }: FilterControlsProp
   }
 
   function clearAll() {
-    onChange({ search: '', schoolLevels: [], starRatings: [] })
+    onChange({ search: '', schoolTypes: [], schoolLevels: [], starRatings: [], proximity: null })
   }
 
   return (
     <div className="bg-white border-b border-gray-200 px-4 py-3 space-y-3">
       <div className="flex items-center gap-3 flex-wrap">
-        {/* Search */}
+        {/* School name search */}
         <input
           type="search"
           placeholder="Search school name…"
           value={filters.search}
           onChange={(e) => onChange({ ...filters, search: e.target.value })}
           className="border border-gray-300 rounded px-3 py-1.5 text-sm flex-1 min-w-[160px] max-w-xs focus:outline-none focus:ring-2 focus:ring-blue-400"
+        />
+
+        {/* Address / proximity search */}
+        <ProximitySearch
+          proximity={filters.proximity}
+          onChange={(proximity) => onChange({ ...filters, proximity })}
         />
 
         {/* Clear */}
@@ -80,6 +97,27 @@ export default function FilterControls({ filters, onChange }: FilterControlsProp
           })}
         </div>
 
+        {/* School type pills */}
+        <div className="flex flex-wrap gap-1 items-center">
+          <span className="text-xs text-gray-500 font-medium mr-1">Type:</span>
+          {ALL_TYPES.map((type) => {
+            const active = filters.schoolTypes.includes(type)
+            return (
+              <button
+                key={type}
+                onClick={() => toggleType(type)}
+                className={`px-2.5 py-0.5 rounded-full text-xs border transition-colors ${
+                  active
+                    ? 'bg-blue-600 text-white border-blue-600'
+                    : 'bg-white text-gray-600 border-gray-300 hover:border-blue-400'
+                }`}
+              >
+                {type}
+              </button>
+            )
+          })}
+        </div>
+
         {/* Star rating buttons */}
         <div className="flex flex-wrap gap-1 items-center">
           <span className="text-xs text-gray-500 font-medium mr-1">Stars:</span>
@@ -101,6 +139,34 @@ export default function FilterControls({ filters, onChange }: FilterControlsProp
             )
           })}
         </div>
+
+        {/* Proximity status */}
+        {filters.proximity && (
+          <div className="flex flex-wrap gap-1 items-center">
+            <span className="text-xs text-gray-700 bg-blue-50 border border-blue-200 rounded-full px-2.5 py-0.5">
+              {filters.proximity.label}
+            </span>
+            {([3, 5, 10] as const).map((r) => (
+              <button
+                key={r}
+                onClick={() => onChange({ ...filters, proximity: { ...filters.proximity!, radiusMiles: r } })}
+                className={`px-2 py-0.5 rounded-full text-xs border transition-colors ${
+                  filters.proximity!.radiusMiles === r
+                    ? 'bg-blue-600 text-white border-blue-600'
+                    : 'bg-white text-gray-600 border-gray-300 hover:border-blue-400'
+                }`}
+              >
+                {r} mi
+              </button>
+            ))}
+            <button
+              onClick={() => onChange({ ...filters, proximity: null })}
+              className="text-xs text-blue-600 hover:underline"
+            >
+              Clear
+            </button>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/src/components/filters/ProximitySearch.tsx
+++ b/src/components/filters/ProximitySearch.tsx
@@ -1,0 +1,88 @@
+'use client'
+
+import { useState } from 'react'
+import type { ProximityFilter } from '@/types/school'
+import { geocodeAddress } from '@/utils/geocode'
+
+interface ProximitySearchProps {
+  proximity: ProximityFilter | null
+  onChange: (proximity: ProximityFilter | null) => void
+}
+
+export default function ProximitySearch({ proximity, onChange }: ProximitySearchProps) {
+  const [address, setAddress] = useState('')
+  const [searching, setSearching] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleSearch() {
+    const trimmed = address.trim()
+    if (!trimmed) return
+    setSearching(true)
+    setError(null)
+    try {
+      const result = await geocodeAddress(trimmed)
+      onChange({ ...result, radiusMiles: proximity?.radiusMiles ?? 3 })
+      setAddress('')
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Geocoding failed')
+    } finally {
+      setSearching(false)
+    }
+  }
+
+  function handleGeolocation() {
+    if (!navigator.geolocation) {
+      setError('Geolocation is not supported by your browser')
+      return
+    }
+    setSearching(true)
+    setError(null)
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        onChange({
+          lat: pos.coords.latitude,
+          lng: pos.coords.longitude,
+          radiusMiles: proximity?.radiusMiles ?? 3,
+          label: 'My location',
+        })
+        setSearching(false)
+      },
+      (err) => {
+        setError(err.message || 'Could not get your location')
+        setSearching(false)
+      }
+    )
+  }
+
+  return (
+    <>
+      <input
+        type="text"
+        placeholder="Enter address…"
+        value={address}
+        onChange={(e) => setAddress(e.target.value)}
+        onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
+        disabled={searching}
+        className="border border-gray-300 rounded px-3 py-1.5 text-sm flex-1 min-w-[160px] max-w-xs focus:outline-none focus:ring-2 focus:ring-blue-400 disabled:opacity-50"
+      />
+      <button
+        onClick={handleSearch}
+        disabled={searching || !address.trim()}
+        className="px-3 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-40 whitespace-nowrap"
+      >
+        {searching ? 'Searching…' : 'Search'}
+      </button>
+      <button
+        onClick={handleGeolocation}
+        disabled={searching}
+        className="px-3 py-1.5 text-sm border border-gray-300 rounded hover:bg-gray-50 disabled:opacity-40 whitespace-nowrap"
+      >
+        Use my location
+      </button>
+
+      {error && (
+        <p className="text-xs text-red-600 w-full">{error}</p>
+      )}
+    </>
+  )
+}

--- a/src/components/map/MapInner.tsx
+++ b/src/components/map/MapInner.tsx
@@ -1,8 +1,10 @@
 'use client'
 
 import 'leaflet/dist/leaflet.css'
-import { MapContainer, TileLayer } from 'react-leaflet'
+import { MapContainer, TileLayer, Marker, Circle, useMap } from 'react-leaflet'
+import { useEffect } from 'react'
 import { useSchools } from '@/hooks/useSchools'
+import { createUserLocationIcon } from '@/utils/markerColors'
 import type { FilterState } from '@/types/school'
 import SchoolMarker from './SchoolMarker'
 
@@ -11,9 +13,19 @@ interface MapInnerProps {
 }
 
 const LAS_VEGAS_CENTER: [number, number] = [36.1716, -115.1391]
+const MILES_TO_METERS = 1609.344
+
+function RecenterMap({ lat, lng }: { lat: number; lng: number }) {
+  const map = useMap()
+  useEffect(() => {
+    map.setView([lat, lng], 12)
+  }, [map, lat, lng])
+  return null
+}
 
 export default function MapInner({ filters }: MapInnerProps) {
   const { schools, loading, error } = useSchools(filters)
+  const proximity = filters.proximity
 
   if (loading) {
     return (
@@ -33,8 +45,8 @@ export default function MapInner({ filters }: MapInnerProps) {
 
   return (
     <MapContainer
-      center={LAS_VEGAS_CENTER}
-      zoom={11}
+      center={proximity ? [proximity.lat, proximity.lng] : LAS_VEGAS_CENTER}
+      zoom={proximity ? 12 : 11}
       className="w-full h-full"
       style={{ zIndex: 0 }}
     >
@@ -42,6 +54,25 @@ export default function MapInner({ filters }: MapInnerProps) {
         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
       />
+      {proximity && (
+        <>
+          <RecenterMap lat={proximity.lat} lng={proximity.lng} />
+          <Circle
+            center={[proximity.lat, proximity.lng]}
+            radius={proximity.radiusMiles * MILES_TO_METERS}
+            pathOptions={{
+              color: '#2563eb',
+              fillColor: '#2563eb',
+              fillOpacity: 0.08,
+              weight: 2,
+            }}
+          />
+          <Marker
+            position={[proximity.lat, proximity.lng]}
+            icon={createUserLocationIcon()}
+          />
+        </>
+      )}
       {schools.map((school) => (
         <SchoolMarker key={school.id} school={school} />
       ))}

--- a/src/components/map/SchoolMarker.tsx
+++ b/src/components/map/SchoolMarker.tsx
@@ -2,10 +2,10 @@
 
 import { Marker, Popup } from 'react-leaflet'
 import { createMarkerIcon } from '@/utils/markerColors'
-import type { School } from '@/types/school'
+import type { SchoolWithDistance } from '@/types/school'
 
 interface SchoolMarkerProps {
-  school: School
+  school: SchoolWithDistance
 }
 
 export default function SchoolMarker({ school }: SchoolMarkerProps) {
@@ -22,11 +22,17 @@ export default function SchoolMarker({ school }: SchoolMarkerProps) {
           <div className="grid grid-cols-2 gap-x-3 gap-y-1 text-xs">
             <span className="text-gray-500">Stars</span>
             <span className="font-medium">{'★'.repeat(school.starRating)}</span>
-            <span className="text-gray-500">Index</span>
+            <span className="text-gray-500">Score</span>
             <span className="font-medium">{school.indexScore}</span>
-            <span className="text-gray-500">ELA%</span>
+            {school.distanceMiles != null && (
+              <>
+                <span className="text-gray-500">Distance</span>
+                <span className="font-medium">{school.distanceMiles.toFixed(1)} mi</span>
+              </>
+            )}
+            <span className="text-gray-500">ELA Prof.</span>
             <span className="font-medium">{school.elaProficiency ?? '—'}</span>
-            <span className="text-gray-500">Math%</span>
+            <span className="text-gray-500">Math Prof.</span>
             <span className="font-medium">{school.mathProficiency ?? '—'}</span>
           </div>
         </div>

--- a/src/components/table/TableView.tsx
+++ b/src/components/table/TableView.tsx
@@ -1,36 +1,57 @@
 'use client'
 
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useEffect } from 'react'
 import { useSchools } from '@/hooks/useSchools'
-import StarRating from '@/components/StarRating'
-import type { FilterState, School } from '@/types/school'
+import StarRatingComponent from '@/components/StarRating'
+import type { FilterState, SchoolWithDistance } from '@/types/school'
 
-type SortKey = keyof Pick<School, 'name' | 'level' | 'starRating' | 'indexScore'>
+type SortKey = 'name' | 'level' | 'type' | 'starRating' | 'indexScore' | 'elaProficiency' | 'mathProficiency' | 'elaGrowth' | 'mathGrowth' | 'distanceMiles'
 
 interface TableViewProps {
   filters: FilterState
 }
 
-const PAGE_SIZE = 25
+const PAGE_SIZE_OPTIONS = [25, 50, 100, 0] as const // 0 = all
 
 export default function TableView({ filters }: TableViewProps) {
   const { schools, loading, error } = useSchools(filters)
-  const [sortKey, setSortKey] = useState<SortKey>('name')
-  const [sortAsc, setSortAsc] = useState(true)
+  const [sortKey, setSortKey] = useState<SortKey>('indexScore')
+  const [sortAsc, setSortAsc] = useState(false)
   const [page, setPage] = useState(0)
+  const [pageSize, setPageSize] = useState<number>(25)
+
+  const hasProximity = filters.proximity !== null
+  const colCount = hasProximity ? 10 : 9
+
+  // Auto-sort by distance when proximity activates
+  useEffect(() => {
+    if (hasProximity) {
+      setSortKey('distanceMiles')
+      setSortAsc(true)
+      setPage(0)
+    } else if (sortKey === 'distanceMiles') {
+      setSortKey('name')
+      setSortAsc(true)
+      setPage(0)
+    }
+  }, [hasProximity]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const sorted = useMemo(() => {
     return [...schools].sort((a, b) => {
-      const av = a[sortKey]
-      const bv = b[sortKey]
+      const av = a[sortKey as keyof SchoolWithDistance]
+      const bv = b[sortKey as keyof SchoolWithDistance]
+      if (av == null && bv == null) return 0
+      if (av == null) return 1
+      if (bv == null) return -1
       if (av < bv) return sortAsc ? -1 : 1
       if (av > bv) return sortAsc ? 1 : -1
       return 0
     })
   }, [schools, sortKey, sortAsc])
 
-  const totalPages = Math.ceil(sorted.length / PAGE_SIZE)
-  const pageSlice = sorted.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE)
+  const effectivePageSize = pageSize === 0 ? sorted.length : pageSize
+  const totalPages = effectivePageSize > 0 ? Math.ceil(sorted.length / effectivePageSize) : 1
+  const pageSlice = pageSize === 0 ? sorted : sorted.slice(page * pageSize, (page + 1) * pageSize)
 
   function handleSort(key: SortKey) {
     if (sortKey === key) {
@@ -42,7 +63,7 @@ export default function TableView({ filters }: TableViewProps) {
     setPage(0)
   }
 
-  const colClass = 'px-3 py-2 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider cursor-pointer select-none whitespace-nowrap'
+  const colClass = 'px-4 py-2 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider cursor-pointer select-none whitespace-nowrap'
   const indicator = (key: SortKey) =>
     sortKey === key ? (sortAsc ? ' ▲' : ' ▼') : ''
 
@@ -62,40 +83,64 @@ export default function TableView({ filters }: TableViewProps) {
               <th className={colClass} onClick={() => handleSort('name')}>
                 School{indicator('name')}
               </th>
-              <th className={colClass + ' hidden sm:table-cell'} onClick={() => handleSort('level')}>
+              {hasProximity && (
+                <th className={colClass + ' w-0 text-right'} onClick={() => handleSort('distanceMiles')}>
+                  Distance{indicator('distanceMiles')}
+                </th>
+              )}
+              <th className={colClass + ' w-0 hidden sm:table-cell'} onClick={() => handleSort('level')}>
                 Level{indicator('level')}
               </th>
-              <th className={colClass} onClick={() => handleSort('starRating')}>
+              <th className={colClass + ' w-0 hidden sm:table-cell'} onClick={() => handleSort('type')}>
+                Type{indicator('type')}
+              </th>
+              <th className={colClass + ' w-0'} onClick={() => handleSort('starRating')}>
                 Stars{indicator('starRating')}
               </th>
-              <th className={colClass} onClick={() => handleSort('indexScore')}>
-                Index{indicator('indexScore')}
+              <th className={colClass + ' w-0 text-right'} onClick={() => handleSort('indexScore')}>
+                Score{indicator('indexScore')}
               </th>
-              <th className={colClass + ' hidden md:table-cell'}>ELA%</th>
-              <th className={colClass + ' hidden md:table-cell'}>Math%</th>
+              <th className={colClass + ' w-0 text-right hidden md:table-cell'} onClick={() => handleSort('elaProficiency')}>ELA Proficiency{indicator('elaProficiency')}</th>
+              <th className={colClass + ' w-0 text-right hidden md:table-cell'} onClick={() => handleSort('mathProficiency')}>Math Proficiency{indicator('mathProficiency')}</th>
+              <th className={colClass + ' w-0 text-right hidden md:table-cell'} onClick={() => handleSort('elaGrowth')}>ELA Growth{indicator('elaGrowth')}</th>
+              <th className={colClass + ' w-0 text-right hidden md:table-cell'} onClick={() => handleSort('mathGrowth')}>Math Growth{indicator('mathGrowth')}</th>
             </tr>
           </thead>
           <tbody className="bg-white divide-y divide-gray-100">
             {pageSlice.length === 0 ? (
               <tr>
-                <td colSpan={6} className="px-3 py-8 text-center text-gray-400">
+                <td colSpan={colCount} className="px-4 py-8 text-center text-gray-400">
                   No schools match your filters.
                 </td>
               </tr>
             ) : (
               pageSlice.map((school) => (
                 <tr key={school.id} className="hover:bg-gray-50">
-                  <td className="px-3 py-2 font-medium text-gray-900">{school.name}</td>
-                  <td className="px-3 py-2 text-gray-500 hidden sm:table-cell">{school.level}{school.type === 'Charter' ? ' · Charter' : ''}</td>
-                  <td className="px-3 py-2">
-                    <StarRating rating={school.starRating} />
+                  <td className="px-4 py-2 font-medium text-gray-900">{school.name}</td>
+                  {hasProximity && (
+                    <td className="px-4 py-2 w-0 text-gray-700 tabular-nums text-right">
+                      {school.distanceMiles != null
+                        ? `${school.distanceMiles.toFixed(1)} mi`
+                        : '—'}
+                    </td>
+                  )}
+                  <td className="px-4 py-2 w-0 text-gray-500 hidden sm:table-cell">{school.level}</td>
+                  <td className="px-4 py-2 w-0 text-gray-500 hidden sm:table-cell">{school.type}</td>
+                  <td className="px-4 py-2 w-0">
+                    <StarRatingComponent rating={school.starRating} />
                   </td>
-                  <td className="px-3 py-2 text-gray-700">{school.indexScore}</td>
-                  <td className="px-3 py-2 text-gray-700 hidden md:table-cell">
-                    {school.elaProficiency ?? '—'}
+                  <td className="px-4 py-2 w-0 text-gray-700 tabular-nums text-right">{school.indexScore.toFixed(1)}</td>
+                  <td className="px-4 py-2 w-0 text-gray-700 tabular-nums text-right hidden md:table-cell">
+                    {school.elaProficiency != null ? `${Number(school.elaProficiency).toFixed(1)}%` : '—'}
                   </td>
-                  <td className="px-3 py-2 text-gray-700 hidden md:table-cell">
-                    {school.mathProficiency ?? '—'}
+                  <td className="px-4 py-2 w-0 text-gray-700 tabular-nums text-right hidden md:table-cell">
+                    {school.mathProficiency != null ? `${Number(school.mathProficiency).toFixed(1)}%` : '—'}
+                  </td>
+                  <td className="px-4 py-2 w-0 text-gray-700 tabular-nums text-right hidden md:table-cell">
+                    {school.elaGrowth != null ? `${Number(school.elaGrowth).toFixed(1)}%` : '—'}
+                  </td>
+                  <td className="px-4 py-2 w-0 text-gray-700 tabular-nums text-right hidden md:table-cell">
+                    {school.mathGrowth != null ? `${Number(school.mathGrowth).toFixed(1)}%` : '—'}
                   </td>
                 </tr>
               ))
@@ -104,29 +149,45 @@ export default function TableView({ filters }: TableViewProps) {
         </table>
       </div>
 
-      {totalPages > 1 && (
-        <div className="flex items-center justify-between px-3 py-2 border-t border-gray-200 bg-white text-sm">
+      <div className="flex items-center justify-between px-3 py-2 border-t border-gray-200 bg-white text-sm">
           <span className="text-gray-500">
-            Page {page + 1} of {totalPages} ({sorted.length} schools)
+            {sorted.length} schools{totalPages > 1 && ` · Page ${page + 1} of ${totalPages}`}
           </span>
-          <div className="flex gap-2">
-            <button
-              onClick={() => setPage((p) => Math.max(0, p - 1))}
-              disabled={page === 0}
-              className="px-3 py-1 rounded border border-gray-300 disabled:opacity-40 hover:bg-gray-50"
-            >
-              Prev
-            </button>
-            <button
-              onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
-              disabled={page === totalPages - 1}
-              className="px-3 py-1 rounded border border-gray-300 disabled:opacity-40 hover:bg-gray-50"
-            >
-              Next
-            </button>
+          <div className="flex items-center gap-3">
+            <div className="flex items-center gap-1">
+              <span className="text-gray-500 text-xs">Show:</span>
+              {PAGE_SIZE_OPTIONS.map((size) => (
+                <button
+                  key={size}
+                  onClick={() => { setPageSize(size); setPage(0) }}
+                  className={`px-2 py-1 rounded text-xs border transition-colors ${
+                    pageSize === size
+                      ? 'bg-blue-600 text-white border-blue-600'
+                      : 'bg-white text-gray-600 border-gray-300 hover:border-blue-400'
+                  }`}
+                >
+                  {size === 0 ? 'All' : size}
+                </button>
+              ))}
+            </div>
+            <div className="flex gap-2">
+              <button
+                onClick={() => setPage((p) => Math.max(0, p - 1))}
+                disabled={page === 0 || totalPages <= 1}
+                className="px-3 py-1 rounded border border-gray-300 disabled:opacity-40 hover:bg-gray-50"
+              >
+                Prev
+              </button>
+              <button
+                onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+                disabled={page === totalPages - 1 || totalPages <= 1}
+                className="px-3 py-1 rounded border border-gray-300 disabled:opacity-40 hover:bg-gray-50"
+              >
+                Next
+              </button>
+            </div>
           </div>
         </div>
-      )}
     </div>
   )
 }

--- a/src/hooks/useSchools.ts
+++ b/src/hooks/useSchools.ts
@@ -1,7 +1,8 @@
 'use client'
 
 import { useState, useEffect, useMemo } from 'react'
-import type { School, FilterState } from '@/types/school'
+import type { School, FilterState, SchoolWithDistance } from '@/types/school'
+import { haversineDistanceMiles } from '@/utils/haversine'
 
 export function useSchools(filters: FilterState) {
   const [schools, setSchools] = useState<School[]>([])
@@ -26,27 +27,55 @@ export function useSchools(filters: FilterState) {
   }, [])
 
   const filtered = useMemo(() => {
-    return schools.filter((school) => {
+    const result: SchoolWithDistance[] = []
+
+    for (const school of schools) {
       if (
         filters.search &&
         !school.name.toLowerCase().includes(filters.search.toLowerCase())
       ) {
-        return false
+        continue
+      }
+      if (
+        filters.schoolTypes.length > 0 &&
+        !filters.schoolTypes.includes(school.type)
+      ) {
+        continue
       }
       if (
         filters.schoolLevels.length > 0 &&
         !filters.schoolLevels.includes(school.level)
       ) {
-        return false
+        continue
       }
       if (
         filters.starRatings.length > 0 &&
         !filters.starRatings.includes(school.starRating)
       ) {
-        return false
+        continue
       }
-      return true
-    })
+
+      let distanceMiles: number | null = null
+
+      if (filters.proximity) {
+        if (school.lat === null || school.lng === null) continue
+        distanceMiles = haversineDistanceMiles(
+          filters.proximity.lat,
+          filters.proximity.lng,
+          school.lat,
+          school.lng
+        )
+        if (distanceMiles > filters.proximity.radiusMiles) continue
+      }
+
+      result.push({ ...school, distanceMiles })
+    }
+
+    if (filters.proximity) {
+      result.sort((a, b) => (a.distanceMiles ?? 0) - (b.distanceMiles ?? 0))
+    }
+
+    return result
   }, [schools, filters])
 
   return { schools: filtered, loading, error }

--- a/src/types/school.ts
+++ b/src/types/school.ts
@@ -19,8 +19,21 @@ export interface School {
   lng: number | null
 }
 
+export interface ProximityFilter {
+  lat: number
+  lng: number
+  radiusMiles: number
+  label: string
+}
+
 export interface FilterState {
   search: string
+  schoolTypes: SchoolType[]
   schoolLevels: SchoolLevel[]
   starRatings: StarRating[]
+  proximity: ProximityFilter | null
+}
+
+export interface SchoolWithDistance extends School {
+  distanceMiles: number | null
 }

--- a/src/utils/geocode.ts
+++ b/src/utils/geocode.ts
@@ -1,0 +1,35 @@
+interface NominatimResult {
+  lat: string
+  lon: string
+  display_name: string
+}
+
+export async function geocodeAddress(
+  address: string
+): Promise<{ lat: number; lng: number; label: string }> {
+  const params = new URLSearchParams({
+    q: address,
+    format: 'json',
+    limit: '1',
+    viewbox: '-115.9,36.8,-114.5,35.5',
+    bounded: '1',
+  })
+
+  const res = await fetch(
+    `https://nominatim.openstreetmap.org/search?${params}`,
+    {
+      headers: { 'User-Agent': 'ccsd-school-ratings/1.0' },
+    }
+  )
+
+  if (!res.ok) throw new Error('Geocoding request failed')
+
+  const data: NominatimResult[] = await res.json()
+  if (data.length === 0) throw new Error('Address not found in Clark County area')
+
+  return {
+    lat: parseFloat(data[0].lat),
+    lng: parseFloat(data[0].lon),
+    label: data[0].display_name.split(',').slice(0, 2).join(','),
+  }
+}

--- a/src/utils/haversine.ts
+++ b/src/utils/haversine.ts
@@ -1,0 +1,16 @@
+const EARTH_RADIUS_MILES = 3958.8
+
+export function haversineDistanceMiles(
+  lat1: number,
+  lng1: number,
+  lat2: number,
+  lng2: number
+): number {
+  const toRad = (deg: number) => (deg * Math.PI) / 180
+  const dLat = toRad(lat2 - lat1)
+  const dLng = toRad(lng2 - lng1)
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLng / 2) ** 2
+  return 2 * EARTH_RADIUS_MILES * Math.asin(Math.sqrt(a))
+}

--- a/src/utils/markerColors.ts
+++ b/src/utils/markerColors.ts
@@ -12,6 +12,24 @@ export function getMarkerColor(starRating: StarRating): string {
   return STAR_COLORS[starRating]
 }
 
+export function createUserLocationIcon() {
+  const L = require('leaflet')
+  return L.divIcon({
+    className: '',
+    html: `<div style="
+      width: 18px;
+      height: 18px;
+      border-radius: 50%;
+      background-color: #2563eb;
+      border: 3px solid white;
+      box-shadow: 0 0 0 2px #2563eb, 0 2px 6px rgba(0,0,0,0.4);
+    "></div>`,
+    iconSize: [18, 18],
+    iconAnchor: [9, 9],
+    popupAnchor: [0, -12],
+  })
+}
+
 export function createMarkerIcon(starRating: StarRating) {
   // Use require to avoid top-level import (SSR-safe when called client-side only)
   const L = require('leaflet')


### PR DESCRIPTION
## Summary
- Add address-based proximity search with configurable radius (3/5/10 mi), geocoding via Nominatim, and haversine distance calculation
- Add school type (Regular/Charter) filter pills alongside existing level and star filters
- Enhance table view with sortable ELA/Math proficiency & growth columns, configurable page sizes, and distance column when proximity is active
- Add user location marker and radius circle overlay on map view with auto-recentering

## Test plan
- [ ] Enter an address in the proximity search box and verify schools filter by radius
- [ ] Toggle radius buttons (3/5/10 mi) and confirm results update
- [ ] Verify distance column appears in table and sorts correctly
- [ ] Test Regular/Charter type filter pills
- [ ] Confirm map shows blue location marker and radius circle
- [ ] Verify table column order: ELA Proficiency, Math Proficiency, ELA Growth, Math Growth
- [ ] Test page size options (25/50/100/All)

🤖 Generated with [Claude Code](https://claude.com/claude-code)