### PR TITLE
Rename repo from ccsd-school-ratings to nv-school-ratings

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
         run: npm run build
         env:
           NODE_ENV: production
-          NEXT_PUBLIC_BASE_PATH: /ccsd-school-ratings
+          NEXT_PUBLIC_BASE_PATH: /nv-school-ratings
 
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project
 
-`ccsd-school-ratings` is a mobile-friendly data visualization website for Clark County School District (CCSD) school performance data. Built with Next.js + TypeScript, hosted on GitHub Pages as a static export.
+`nv-school-ratings` is a mobile-friendly data visualization website for Nevada school performance data. Built with Next.js + TypeScript, hosted on GitHub Pages as a static export.
 
 ## Commands
 
@@ -17,7 +17,7 @@ npx serve out    # Preview production build locally
 
 For a production-accurate local preview:
 ```bash
-NODE_ENV=production NEXT_PUBLIC_BASE_PATH=/ccsd-school-ratings npm run build
+NODE_ENV=production NEXT_PUBLIC_BASE_PATH=/nv-school-ratings npm run build
 ```
 
 ## Architecture
@@ -27,7 +27,7 @@ NODE_ENV=production NEXT_PUBLIC_BASE_PATH=/ccsd-school-ratings npm run build
 **Key files**:
 - `next.config.ts` — `output: 'export'`, `basePath`/`assetPrefix` for GitHub Pages, `trailingSlash: true`
 - `src/types/school.ts` — `School` interface and `FilterState` type
-- `public/data/schools.json` — school data (replace placeholder with real CCSD data)
+- `public/data/schools.json` — school data
 - `src/hooks/useSchools.ts` — client-side data fetch + filter logic; prefixes URL with `NEXT_PUBLIC_BASE_PATH`
 - `src/utils/markerColors.ts` — star rating → color mapping; `createMarkerIcon()` using `L.divIcon`
 - `.github/workflows/deploy.yml` — CI/CD to GitHub Pages

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# ccsd-school-ratings
+# nv-school-ratings

--- a/next.config.ts
+++ b/next.config.ts
@@ -4,8 +4,8 @@ const isProd = process.env.NODE_ENV === 'production'
 
 const nextConfig: NextConfig = {
   output: 'export',
-  basePath: isProd ? '/ccsd-school-ratings' : '',
-  assetPrefix: isProd ? '/ccsd-school-ratings' : '',
+  basePath: isProd ? '/nv-school-ratings' : '',
+  assetPrefix: isProd ? '/nv-school-ratings' : '',
   images: { unoptimized: true },
   trailingSlash: true,
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "ccsd-school-ratings",
+  "name": "nv-school-ratings",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "ccsd-school-ratings",
+      "name": "nv-school-ratings",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ccsd-school-ratings",
+  "name": "nv-school-ratings",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/scripts/geocode-schools.mjs
+++ b/scripts/geocode-schools.mjs
@@ -6,7 +6,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const schoolsPath = join(__dirname, '..', 'public', 'data', 'schools.json')
 
 const DELAY_MS = 1100 // Nominatim rate limit: 1 req/sec
-const USER_AGENT = 'ccsd-school-ratings/1.0 (github.com/ccsd-school-ratings)'
+const USER_AGENT = 'nv-school-ratings/1.0 (github.com/nv-school-ratings)'
 
 function sleep(ms) {
   return new Promise((r) => setTimeout(r, ms))

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,8 +2,8 @@ import type { Metadata, Viewport } from 'next'
 import './globals.css'
 
 export const metadata: Metadata = {
-  title: 'CCSD School Ratings',
-  description: 'Clark County School District school performance ratings and data visualization',
+  title: 'NV School Ratings',
+  description: 'Nevada school performance ratings and data visualization',
 }
 
 export const viewport: Viewport = {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -23,7 +23,7 @@ export default function Home() {
       {/* Header */}
       <header className="bg-white border-b border-gray-200 px-4 py-3 flex items-center justify-between gap-4 shrink-0">
         <h1 className="text-base font-semibold text-gray-900 leading-tight">
-          CCSD School Ratings
+          NV School Ratings
         </h1>
         {/* View toggle */}
         <div className="flex rounded-lg border border-gray-300 overflow-hidden text-sm shrink-0">

--- a/src/utils/geocode.ts
+++ b/src/utils/geocode.ts
@@ -18,7 +18,7 @@ export async function geocodeAddress(
   const res = await fetch(
     `https://nominatim.openstreetmap.org/search?${params}`,
     {
-      headers: { 'User-Agent': 'ccsd-school-ratings/1.0' },
+      headers: { 'User-Agent': 'nv-school-ratings/1.0' },
     }
   )
 


### PR DESCRIPTION
## Summary
- Update all internal references (basePath, assetPrefix, metadata, user-agent strings, package name) from `ccsd-school-ratings` to `nv-school-ratings`
- Update display titles from "CCSD School Ratings" to "NV School Ratings"
- Update CLAUDE.md project description to reflect statewide scope

## Test plan
- [ ] Verify `npm run build` succeeds with updated basePath
- [ ] Verify GitHub Pages deployment uses correct `/nv-school-ratings` path
- [ ] Confirm no remaining references to `ccsd-school-ratings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)