### PR TITLE
Add table-to-map navigation for school selection

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import type { FilterState } from '@/types/school'
+import type { FilterState, School } from '@/types/school'
 import FilterControls from '@/components/filters/FilterControls'
 import MapView from '@/components/map/MapView'
 import TableView from '@/components/table/TableView'
@@ -18,6 +18,12 @@ const DEFAULT_FILTERS: FilterState = {
 export default function Home() {
   const [view, setView] = useState<'map' | 'table'>('map')
   const [filters, setFilters] = useState<FilterState>(DEFAULT_FILTERS)
+  const [selectedSchool, setSelectedSchool] = useState<School | null>(null)
+
+  function handleSelectSchool(school: School) {
+    setSelectedSchool(school)
+    setView('map')
+  }
 
   return (
     <div className="flex flex-col h-screen bg-gray-50">
@@ -47,7 +53,7 @@ export default function Home() {
             Map
           </button>
           <button
-            onClick={() => setView('table')}
+            onClick={() => { setView('table'); setSelectedSchool(null) }}
             className={`px-3 py-1.5 border-l border-gray-300 transition-colors ${
               view === 'table'
                 ? 'bg-blue-600 text-white'
@@ -64,11 +70,12 @@ export default function Home() {
 
       {/* Main content */}
       <main className="flex-1 overflow-hidden">
-        {view === 'map' ? (
-          <MapView filters={filters} />
-        ) : (
-          <TableView filters={filters} />
-        )}
+        <div className={view === 'map' ? 'h-full' : 'hidden'}>
+          <MapView filters={filters} selectedSchool={selectedSchool} isVisible={view === 'map'} />
+        </div>
+        <div className={view === 'table' ? 'h-full' : 'hidden'}>
+          <TableView filters={filters} onSelectSchool={handleSelectSchool} />
+        </div>
       </main>
     </div>
   )

--- a/src/components/map/MapInner.tsx
+++ b/src/components/map/MapInner.tsx
@@ -5,11 +5,13 @@ import { MapContainer, TileLayer, Marker, Circle, useMap } from 'react-leaflet'
 import { useEffect } from 'react'
 import { useSchools } from '@/hooks/useSchools'
 import { createUserLocationIcon } from '@/utils/markerColors'
-import type { FilterState } from '@/types/school'
+import type { FilterState, School } from '@/types/school'
 import SchoolMarker from './SchoolMarker'
 
 interface MapInnerProps {
   filters: FilterState
+  selectedSchool?: School | null
+  isVisible?: boolean
 }
 
 const NEVADA_CENTER: [number, number] = [38.8, -116.8]
@@ -44,6 +46,26 @@ function RecenterMap({ lat, lng }: { lat: number; lng: number }) {
   return null
 }
 
+function FlyToSchool({ school }: { school: School }) {
+  const map = useMap()
+  useEffect(() => {
+    if (school.lat && school.lng) {
+      map.flyTo([school.lat, school.lng], 14)
+    }
+  }, [school, map])
+  return null
+}
+
+function InvalidateOnShow({ isVisible }: { isVisible: boolean }) {
+  const map = useMap()
+  useEffect(() => {
+    if (isVisible) {
+      requestAnimationFrame(() => map.invalidateSize())
+    }
+  }, [isVisible, map])
+  return null
+}
+
 function CountyFocus({ county }: { county: string | null }) {
   const map = useMap()
   useEffect(() => {
@@ -57,7 +79,7 @@ function CountyFocus({ county }: { county: string | null }) {
   return null
 }
 
-export default function MapInner({ filters }: MapInnerProps) {
+export default function MapInner({ filters, selectedSchool, isVisible }: MapInnerProps) {
   const { schools, loading, error } = useSchools(filters)
   const proximity = filters.proximity
 
@@ -88,6 +110,8 @@ export default function MapInner({ filters }: MapInnerProps) {
         url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
         attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
       />
+      <InvalidateOnShow isVisible={isVisible ?? true} />
+      {selectedSchool && <FlyToSchool school={selectedSchool} />}
       {!proximity && <CountyFocus county={filters.county} />}
       {proximity && (
         <>
@@ -109,7 +133,7 @@ export default function MapInner({ filters }: MapInnerProps) {
         </>
       )}
       {schools.map((school) => (
-        <SchoolMarker key={school.id} school={school} />
+        <SchoolMarker key={school.id} school={school} isSelected={selectedSchool?.id === school.id} />
       ))}
     </MapContainer>
   )

--- a/src/components/map/MapView.tsx
+++ b/src/components/map/MapView.tsx
@@ -1,5 +1,5 @@
 import dynamic from 'next/dynamic'
-import type { FilterState } from '@/types/school'
+import type { FilterState, School } from '@/types/school'
 
 const MapInner = dynamic(() => import('./MapInner'), {
   ssr: false,
@@ -12,12 +12,14 @@ const MapInner = dynamic(() => import('./MapInner'), {
 
 interface MapViewProps {
   filters: FilterState
+  selectedSchool?: School | null
+  isVisible?: boolean
 }
 
-export default function MapView({ filters }: MapViewProps) {
+export default function MapView({ filters, selectedSchool, isVisible }: MapViewProps) {
   return (
     <div className="w-full h-full">
-      <MapInner filters={filters} />
+      <MapInner filters={filters} selectedSchool={selectedSchool} isVisible={isVisible} />
     </div>
   )
 }

--- a/src/components/map/SchoolMarker.tsx
+++ b/src/components/map/SchoolMarker.tsx
@@ -1,22 +1,32 @@
 'use client'
 
+import { useEffect, useRef } from 'react'
 import { Marker, Popup } from 'react-leaflet'
+import type L from 'leaflet'
 import { createMarkerIcon } from '@/utils/markerColors'
 import type { SchoolWithDistance } from '@/types/school'
 
 interface SchoolMarkerProps {
   school: SchoolWithDistance
+  isSelected?: boolean
 }
 
-export default function SchoolMarker({ school }: SchoolMarkerProps) {
+export default function SchoolMarker({ school, isSelected }: SchoolMarkerProps) {
   const icon = createMarkerIcon(school.starRating)
+  const markerRef = useRef<L.Marker>(null)
+
+  useEffect(() => {
+    if (isSelected && markerRef.current) {
+      markerRef.current.openPopup()
+    }
+  }, [isSelected])
 
   if (school.lat === null || school.lng === null) return null
 
   return (
-    <Marker position={[school.lat, school.lng]} icon={icon}>
+    <Marker ref={markerRef} position={[school.lat, school.lng]} icon={icon}>
       <Popup>
-        <div className="min-w-[180px]">
+        <div className="min-w-[220px]">
           <div className="flex items-baseline justify-between gap-2">
             <p className="font-semibold text-sm">{school.name}</p>
             {school.distanceMiles != null && (

--- a/src/components/table/TableView.tsx
+++ b/src/components/table/TableView.tsx
@@ -3,17 +3,18 @@
 import { useState, useMemo, useEffect } from 'react'
 import { useSchools } from '@/hooks/useSchools'
 import StarRatingComponent from '@/components/StarRating'
-import type { FilterState, SchoolWithDistance } from '@/types/school'
+import type { FilterState, School, SchoolWithDistance } from '@/types/school'
 
 type SortKey = 'name' | 'level' | 'type' | 'starRating' | 'indexScore' | 'elaProficiency' | 'mathProficiency' | 'elaGrowth' | 'mathGrowth' | 'distanceMiles'
 
 interface TableViewProps {
   filters: FilterState
+  onSelectSchool?: (school: School) => void
 }
 
 const PAGE_SIZE_OPTIONS = [25, 50, 100, 0] as const // 0 = all
 
-export default function TableView({ filters }: TableViewProps) {
+export default function TableView({ filters, onSelectSchool }: TableViewProps) {
   const { schools, loading, error } = useSchools(filters)
   const [sortKey, setSortKey] = useState<SortKey>('indexScore')
   const [sortAsc, setSortAsc] = useState(false)
@@ -116,7 +117,16 @@ export default function TableView({ filters }: TableViewProps) {
             ) : (
               pageSlice.map((school) => (
                 <tr key={school.id} className="hover:bg-gray-50">
-                  <td className="px-4 py-2 font-medium text-gray-900">{school.name}</td>
+                  <td className="px-4 py-2 font-medium text-gray-900">
+                    {onSelectSchool ? (
+                      <button
+                        onClick={() => onSelectSchool(school)}
+                        className="cursor-pointer text-blue-600 hover:underline text-left"
+                      >
+                        {school.name}
+                      </button>
+                    ) : school.name}
+                  </td>
                   {hasProximity && (
                     <td className="px-4 py-2 w-0 text-gray-700 tabular-nums text-right">
                       {school.distanceMiles != null


### PR DESCRIPTION
## Summary
- Clicking a school name in the table view now switches to the map, flies to the school's location, and opens its popup
- Both map and table views are rendered simultaneously with CSS show/hide, preventing the map from remounting on tab toggle
- `InvalidateOnShow` fixes Leaflet tile rendering when the map container becomes visible after being hidden

## Test plan
- [ ] Open the table view and click a school name — verify the map switches to that school with popup open
- [ ] Verify the map renders correctly (no blank tiles) when switching back and forth between views
- [ ] Verify clicking "Table" button clears the selected school (no popup re-fires on next visit)
- [ ] Verify all existing filter/sort/pagination behavior in table is unchanged
- [ ] Test on mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)