### PR TITLE
Fix favicon missing on GitHub Pages (basePath prefix)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,10 +1,12 @@
 import type { Metadata, Viewport } from 'next'
 import './globals.css'
 
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH || ''
+
 export const metadata: Metadata = {
   title: 'NV School Ratings',
   description: 'Nevada school performance ratings and data visualization',
-  icons: { icon: '/favicon.svg' },
+  icons: { icon: `${basePath}/favicon.svg` },
 }
 
 export const viewport: Viewport = {


### PR DESCRIPTION
## Summary
- Next.js static export doesn't apply `basePath` to the `<link rel="icon">` tag, causing the favicon to 404 on GitHub Pages
- Prefix the icon path with `NEXT_PUBLIC_BASE_PATH` in `layout.tsx`, matching the same pattern used for the data fetch URL in `useSchools.ts`
- Verified: built `out/index.html` now contains `href="/nv-school-ratings/favicon.svg"`

## Test plan
- [ ] Run `NODE_ENV=production NEXT_PUBLIC_BASE_PATH=/nv-school-ratings npm run build`
- [ ] Confirm `grep 'rel="icon"' out/index.html` shows `href="/nv-school-ratings/favicon.svg"`
- [ ] Deploy and verify favicon appears in browser tab on the live GitHub Pages site

🤖 Generated with [Claude Code](https://claude.com/claude-code)