### PR TITLE
Fix build script to output District instead of Regular school type

### DIFF
--- a/scripts/build-nv-schools.mjs
+++ b/scripts/build-nv-schools.mjs
@@ -428,7 +428,7 @@ for (const row of ratingsRows) {
   if (indexScore === null) { filtered++; continue }
 
   const name = row['School Name'].trim()
-  const schoolType = type === 'District Charter' || type === 'SPCSA' ? 'Charter' : 'Regular'
+  const schoolType = type === 'District Charter' || type === 'SPCSA' ? 'Charter' : 'District'
   const level = inferLevel(name)
 
   // 1. Exact name match


### PR DESCRIPTION
## Summary
- Updates `build-nv-schools.mjs` to assign `'District'` instead of `'Regular'` for non-charter school types
- Keeps the build script in sync with the rename done in PR #13

## Test plan
- [ ] Run `node scripts/build-nv-schools.mjs` and verify output JSON has `"type": "District"` for non-charter schools

🤖 Generated with [Claude Code](https://claude.com/claude-code)