### PR TITLE
Fix ESLint config: ignore build artifacts, add tsx support, fix npm ci

### DIFF
--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -4,6 +4,16 @@ import tseslint from "typescript-eslint";
 import { defineConfig } from "eslint/config";
 
 export default defineConfig([
-  { files: ["**/*.{js,mjs,cjs,ts,mts,cts}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: globals.browser } },
+  { ignores: [".next/**", "out/**", "node_modules/**"] },
+  {
+    files: ["**/*.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],
+    plugins: { js },
+    extends: ["js/recommended"],
+    languageOptions: { globals: globals.browser },
+  },
+  {
+    files: ["scripts/**/*.{js,mjs,cjs,ts}"],
+    languageOptions: { globals: globals.node },
+  },
   tseslint.configs.recommended,
 ]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "tailwindcss": "^4.2.1"
       },
       "devDependencies": {
-        "@eslint/js": "^10.0.1",
+        "@eslint/js": "^9.0.0",
         "@turf/boolean-point-in-polygon": "^7.3.4",
         "@turf/helpers": "^7.3.4",
         "@turf/simplify": "^7.3.4",
@@ -430,23 +430,15 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
-      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
       "dev": true,
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://eslint.org/donate"
-      },
-      "peerDependencies": {
-        "eslint": "^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "eslint": {
-          "optional": true
-        }
       }
     },
     "node_modules/@eslint/object-schema": {
@@ -3378,18 +3370,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/@eslint/js": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
-      "dev": true,
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/espree": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "tailwindcss": "^4.2.1"
   },
   "devDependencies": {
-    "@eslint/js": "^10.0.1",
+    "@eslint/js": "^9.0.0",
     "@turf/boolean-point-in-polygon": "^7.3.4",
     "@turf/helpers": "^7.3.4",
     "@turf/simplify": "^7.3.4",

--- a/src/components/table/TableView.tsx
+++ b/src/components/table/TableView.tsx
@@ -40,7 +40,7 @@ export default function TableView({ filters, onSelectSchool }: TableViewProps) {
       setSortAsc(true)
       setPage(0)
     }
-  }, [hasProximity]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [hasProximity])
 
   const sorted = useMemo(() => {
     return [...schools].sort((a, b) => {

--- a/src/utils/markerColors.ts
+++ b/src/utils/markerColors.ts
@@ -13,6 +13,7 @@ export function getMarkerColor(starRating: StarRating | null): string {
 }
 
 export function createUserLocationIcon() {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
   const L = require('leaflet')
   return L.divIcon({
     className: '',
@@ -32,6 +33,7 @@ export function createUserLocationIcon() {
 
 export function createMarkerIcon(starRating: StarRating | null) {
   // Use require to avoid top-level import (SSR-safe when called client-side only)
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
   const L = require('leaflet')
   const color = getMarkerColor(starRating)
   return L.divIcon({


### PR DESCRIPTION
## Summary
- Add `ignores` block for `.next/`, `out/`, `node_modules/` — prevents ESLint from linting thousands of Turbopack/Next.js build artifacts that were causing hundreds of false-positive errors
- Extend `files` glob to include `*.jsx`/`*.tsx`, which are the primary source files in this Next.js project
- Downgrade `@eslint/js` from `^10` to `^9` to match `eslint@9`, fixing the `ERESOLVE` peer dependency conflict that broke `npm ci`

## Test plan
- [ ] `npm ci` completes without ERESOLVE error
- [ ] `npm run lint` reports 0 errors (previously hundreds from `.next/` artifacts)
- [ ] `npm run build` succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)