### PR TITLE
Configure custom domain for GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,6 @@ jobs:
         run: npm run build
         env:
           NODE_ENV: production
-          NEXT_PUBLIC_BASE_PATH: /nv-school-ratings
 
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,11 +1,7 @@
 import type { NextConfig } from 'next'
 
-const isProd = process.env.NODE_ENV === 'production'
-
 const nextConfig: NextConfig = {
   output: 'export',
-  basePath: isProd ? '/nv-school-ratings' : '',
-  assetPrefix: isProd ? '/nv-school-ratings' : '',
   images: { unoptimized: true },
   trailingSlash: true,
 }

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+nevadaschoolratings.com


### PR DESCRIPTION
## Summary
- Add `public/CNAME` with `nevadaschoolratings.com` so GitHub Pages serves from the custom domain
- Remove `basePath` and `assetPrefix` from `next.config.ts` since the site now serves from `/`
- Remove `NEXT_PUBLIC_BASE_PATH` env var from the deploy workflow

## Test plan
- [ ] Verify GitHub Actions build succeeds after merge
- [ ] Confirm DNS A records resolve to GitHub Pages IPs (`dig nevadaschoolratings.com`)
- [ ] Visit https://nevadaschoolratings.com and verify the site loads correctly
- [ ] Enable "Enforce HTTPS" in repo Settings → Pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)