### PR TITLE
Update title to Nevada School Ratings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# NV School Ratings
+# Nevada School Ratings
 
 A mobile-friendly data visualization tool for Nevada public school performance data. Browse all rated schools on an interactive map or sortable table, and filter by name, location, star rating, school level, type, and county.
 
-**Live site:** https://matthewbeck0715.github.io/nv-school-ratings/
+**Live site:** https://nevadaschoolratings.com/
 
 ## Features
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,7 +5,7 @@ const basePath = process.env.NEXT_PUBLIC_BASE_PATH || ''
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://nevadaschoolratings.com'),
-  title: 'Nevada School Rating',
+  title: 'Nevada School Ratings',
   description:
     'Explore Nevada school star ratings, performance data, and school zone information. Search, filter, and compare schools across the state with interactive maps and tables.',
   keywords: [

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,7 +5,7 @@ const basePath = process.env.NEXT_PUBLIC_BASE_PATH || ''
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://nevadaschoolratings.com'),
-  title: 'Nevada School Ratings — Star Ratings & Performance Data for Every School',
+  title: 'Nevada School Rating',
   description:
     'Explore Nevada school star ratings, performance data, and school zone information. Search, filter, and compare schools across the state with interactive maps and tables.',
   keywords: [

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -38,7 +38,7 @@ export default function Home() {
             height={28}
           />
           <h1 className="text-base font-semibold text-gray-900 leading-tight">
-            NV School Ratings
+            Nevada School Ratings
           </h1>
         </div>
         {/* View toggle */}


### PR DESCRIPTION
## Summary
- Rename "NV School Ratings" → "Nevada School Ratings" in page title, browser tab, and header
- Update live site URL in README to nevadaschoolratings.com

## Test plan
- [ ] Verify browser tab shows "Nevada School Ratings"
- [ ] Verify page header shows "Nevada School Ratings"
- [ ] Verify README links to correct live site URL