### PR TITLE
Auto-set county filter from proximity search

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -42,7 +42,7 @@ When the user runs `/pr <branch-name>`, execute the following workflow. Stop and
 - Use `gh pr create` targeting `main` with this format:
 
 ```
-gh pr create --title "<short title>" --body "$(cat <<'EOF'
+gh pr create --title "<short title>" --assignee @me --body "$(cat <<'EOF'
 ## Summary
 <1-3 bullet points describing the changes>
 

--- a/src/components/filters/FilterControls.tsx
+++ b/src/components/filters/FilterControls.tsx
@@ -68,7 +68,7 @@ export default function FilterControls({ filters, onChange }: FilterControlsProp
         {/* Address / proximity search */}
         <ProximitySearch
           proximity={filters.proximity}
-          onChange={(proximity) => onChange({ ...filters, proximity })}
+          onChange={(proximity, county) => onChange({ ...filters, proximity, county })}
         />
 
         {/* Clear */}

--- a/src/components/filters/ProximitySearch.tsx
+++ b/src/components/filters/ProximitySearch.tsx
@@ -2,11 +2,11 @@
 
 import { useState } from 'react'
 import type { ProximityFilter } from '@/types/school'
-import { geocodeAddress } from '@/utils/geocode'
+import { geocodeAddress, reverseGeocode } from '@/utils/geocode'
 
 interface ProximitySearchProps {
   proximity: ProximityFilter | null
-  onChange: (proximity: ProximityFilter | null) => void
+  onChange: (proximity: ProximityFilter | null, county: string | null) => void
 }
 
 export default function ProximitySearch({ proximity, onChange }: ProximitySearchProps) {
@@ -21,7 +21,7 @@ export default function ProximitySearch({ proximity, onChange }: ProximitySearch
     setError(null)
     try {
       const result = await geocodeAddress(trimmed)
-      onChange({ ...result, radiusMiles: proximity?.radiusMiles ?? 0 })
+      onChange({ ...result, radiusMiles: proximity?.radiusMiles ?? 0 }, result.county)
       setAddress('')
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Geocoding failed')
@@ -38,13 +38,15 @@ export default function ProximitySearch({ proximity, onChange }: ProximitySearch
     setSearching(true)
     setError(null)
     navigator.geolocation.getCurrentPosition(
-      (pos) => {
+      async (pos) => {
+        const { latitude: lat, longitude: lng } = pos.coords
+        const { county } = await reverseGeocode(lat, lng)
         onChange({
-          lat: pos.coords.latitude,
-          lng: pos.coords.longitude,
+          lat,
+          lng,
           radiusMiles: proximity?.radiusMiles ?? 0,
           label: 'My location',
-        })
+        }, county)
         setSearching(false)
       },
       (err) => {

--- a/src/utils/geocode.ts
+++ b/src/utils/geocode.ts
@@ -5,12 +5,21 @@ interface NominatimResult {
   address?: {
     house_number?: string
     road?: string
+    county?: string
+    city?: string
   }
+}
+
+function parseCounty(address?: NominatimResult['address']): string | null {
+  if (!address) return null
+  if (address.county) return address.county.replace(/ County$/, '')
+  if (address.city === 'Carson City') return 'Carson City'
+  return null
 }
 
 export async function geocodeAddress(
   address: string
-): Promise<{ lat: number; lng: number; label: string }> {
+): Promise<{ lat: number; lng: number; label: string; county: string | null }> {
   const params = new URLSearchParams({
     q: `${address}, Nevada`,
     format: 'json',
@@ -36,5 +45,30 @@ export async function geocodeAddress(
     lat: parseFloat(data[0].lat),
     lng: parseFloat(data[0].lon),
     label: [data[0].address?.house_number, data[0].address?.road].filter(Boolean).join(' ') || address.split(',')[0].trim(),
+    county: parseCounty(data[0].address),
   }
+}
+
+export async function reverseGeocode(
+  lat: number,
+  lng: number
+): Promise<{ county: string | null }> {
+  const params = new URLSearchParams({
+    lat: String(lat),
+    lon: String(lng),
+    format: 'json',
+    addressdetails: '1',
+  })
+
+  const res = await fetch(
+    `https://nominatim.openstreetmap.org/reverse?${params}`,
+    {
+      headers: { 'User-Agent': 'nv-school-ratings/1.0' },
+    }
+  )
+
+  if (!res.ok) return { county: null }
+
+  const data: NominatimResult = await res.json()
+  return { county: parseCounty(data.address) }
 }


### PR DESCRIPTION
## Summary
- `geocodeAddress()` now returns a `county` field parsed from Nominatim's address response (strips ` County` suffix, handles Carson City edge case)
- Added `reverseGeocode()` to look up county from lat/lng for the "Use my location" flow
- `ProximitySearch.onChange` signature updated to carry `county` alongside proximity, eliminating a separate callback; `FilterControls` updates both in one call

## Test plan
- [ ] Enter a Las Vegas address → county dropdown auto-selects "Clark"
- [ ] Enter a Reno address → county dropdown auto-selects "Washoe"
- [ ] Enter a Carson City address → county dropdown auto-selects "Carson City"
- [ ] Use "Use my location" → county filter auto-sets based on reverse geocode
- [ ] Click "Clear filters" → county resets to "All"

🤖 Generated with [Claude Code](https://claude.com/claude-code)