### PR TITLE
Truncate long school names in cards and popups

### DIFF
--- a/src/components/map/SchoolMarker.tsx
+++ b/src/components/map/SchoolMarker.tsx
@@ -28,7 +28,7 @@ export default function SchoolMarker({ school, isSelected }: SchoolMarkerProps) 
       <Popup>
         <div className="min-w-[220px]">
           <div className="flex items-baseline justify-between gap-2">
-            <p className="font-semibold text-sm">{school.name}</p>
+            <p className="font-semibold text-sm truncate min-w-0">{school.name}</p>
             {school.distanceMiles != null && (
               <span className="text-xs font-medium text-gray-500 shrink-0">{school.distanceMiles.toFixed(1)} mi</span>
             )}

--- a/src/components/zones/SchoolCard.tsx
+++ b/src/components/zones/SchoolCard.tsx
@@ -22,7 +22,7 @@ export default function SchoolCard({ school, distanceMiles, onSelect }: SchoolCa
       <div className="flex gap-4 items-start">
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
-            <p className="font-semibold text-gray-900 text-sm leading-tight">{school.name}</p>
+            <p className="font-semibold text-gray-900 text-sm leading-tight truncate">{school.name}</p>
             {distanceMiles != null && (
               <span className="text-xs text-gray-400 shrink-0">{distanceMiles.toFixed(1)} mi</span>
             )}


### PR DESCRIPTION
## Summary
- Adds `truncate` class to school name `<p>` in `SchoolCard` so long names are cut with an ellipsis in proximity results cards
- Adds `truncate min-w-0` to school name `<p>` in `SchoolMarker` popup (`min-w-0` is required for truncation inside a flex child)

## Test plan
- [ ] Open map view and click a marker for a school with a long name — popup name should truncate with ellipsis
- [ ] Open proximity results panel — school card names should truncate rather than wrap or overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)