### PR TITLE
Expand side panel to show results for any active filter

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,7 +12,7 @@ import ProximitySearch from '@/components/filters/ProximitySearch'
 import ProximityStatus from '@/components/filters/ProximityStatus'
 import MapView from '@/components/map/MapView'
 import TableView from '@/components/table/TableView'
-import ProximityResults from '@/components/panel/ProximityResults'
+import FilterResults from '@/components/panel/FilterResults'
 
 const DEFAULT_FILTERS: FilterState = {
   search: '',
@@ -128,29 +128,23 @@ export default function Home() {
 
       {/* Main content */}
       <main className="flex-1 overflow-hidden">
-        {filters.proximity && view === 'map' ? (
-          <div className="flex flex-col sm:flex-row h-full">
+        <div className={view === 'map' ? 'flex flex-col sm:flex-row h-full' : 'hidden'}>
+          {hasActive && (
             <div className="shrink-0 sm:w-1/3 sm:border-r border-gray-200 overflow-y-auto">
-              <ProximityResults
+              <FilterResults
                 filters={filters}
                 onSelectSchool={handleSelectSchool}
                 onZoneResult={(ids) => setFilters((f) => ({ ...f, zonedSchoolIds: ids }))}
               />
             </div>
-            <div className="flex-1 min-h-0">
-              <MapView filters={filters} selectedSchool={selectedSchool} isVisible={view === 'map'} />
-            </div>
+          )}
+          <div className="flex-1 min-h-0">
+            <MapView filters={filters} selectedSchool={selectedSchool} isVisible={view === 'map'} />
           </div>
-        ) : (
-          <>
-            <div className={view === 'map' ? 'h-full' : 'hidden'}>
-              <MapView filters={filters} selectedSchool={selectedSchool} isVisible={view === 'map'} />
-            </div>
-            <div className={view === 'table' ? 'h-full' : 'hidden'}>
-              <TableView filters={filters} onSelectSchool={handleSelectSchool} />
-            </div>
-          </>
-        )}
+        </div>
+        <div className={view === 'table' ? 'h-full' : 'hidden'}>
+          <TableView filters={filters} onSelectSchool={handleSelectSchool} />
+        </div>
       </main>
     </div>
   )

--- a/src/components/map/MapInner.tsx
+++ b/src/components/map/MapInner.tsx
@@ -50,7 +50,7 @@ function FlyToSchool({ school }: { school: School }) {
   const map = useMap()
   useEffect(() => {
     if (school.lat && school.lng) {
-      map.flyTo([school.lat, school.lng], 14)
+      map.flyTo([school.lat, school.lng], 12)
     }
   }, [school, map])
   return null

--- a/src/components/panel/FilterResults.tsx
+++ b/src/components/panel/FilterResults.tsx
@@ -1,0 +1,107 @@
+'use client'
+
+import { useState, useEffect, useRef } from 'react'
+import type { FilterState, School } from '@/types/school'
+import { useSchools } from '@/hooks/useSchools'
+import { useSchoolZones } from '@/hooks/useSchoolZones'
+import { findSchoolZonesForPoint, type ZoneLookupResult } from '@/utils/findSchoolZones'
+import SchoolCard from './SchoolCard'
+
+const EMPTY_FILTERS: FilterState = { search: '', schoolTypes: [], schoolLevels: [], starRatings: [], county: null, proximity: null, zonedSchoolIds: null }
+
+interface FilterResultsProps {
+  filters: FilterState
+  onSelectSchool: (school: School) => void
+  onZoneResult: (ids: string[] | null) => void
+}
+
+function ProximityPanel({ filters, onSelectSchool, onZoneResult }: FilterResultsProps) {
+  const proximity = filters.proximity!
+  const isZone = proximity.radiusMiles === 0
+
+  const { schools: allSchools } = useSchools(EMPTY_FILTERS)
+  const { geojson, loading: zonesLoading } = useSchoolZones(true)
+  const [zoneResult, setZoneResult] = useState<ZoneLookupResult | null>(null)
+  const onZoneResultRef = useRef(onZoneResult)
+  onZoneResultRef.current = onZoneResult
+
+  useEffect(() => {
+    onZoneResultRef.current(null)
+    if (!geojson || !allSchools.length) return
+    const r = findSchoolZonesForPoint(proximity.lat, proximity.lng, geojson as never, allSchools)
+    setZoneResult(r)
+    const ids = [r.Elementary?.id, r.Middle?.id, r.High?.id].filter((id): id is string => id != null)
+    onZoneResultRef.current(ids.length > 0 ? ids : null)
+  }, [proximity.lat, proximity.lng, geojson, allSchools])
+
+  const { schools: nearbySchools, loading: nearbyLoading } = useSchools(filters)
+
+  const loading = isZone ? zonesLoading : nearbyLoading
+
+  if (loading) return (
+    <div className="bg-white px-4 py-2 text-xs text-gray-500">
+      Loading…
+    </div>
+  )
+
+  if (isZone) {
+    if (!zoneResult || (!zoneResult.Elementary && !zoneResult.Middle && !zoneResult.High)) return null
+    return (
+      <div className="bg-white px-4 py-3 h-full">
+        <p className="text-xs text-gray-500 font-medium mb-2">Schools zoned for {proximity.label}</p>
+        <div className="flex flex-col gap-3">
+          {zoneResult.Elementary && <SchoolCard school={zoneResult.Elementary} onSelect={onSelectSchool} />}
+          {zoneResult.Middle && <SchoolCard school={zoneResult.Middle} onSelect={onSelectSchool} />}
+          {zoneResult.High && <SchoolCard school={zoneResult.High} onSelect={onSelectSchool} />}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="bg-white px-4 py-3 h-full">
+      <p className="text-xs text-gray-500 font-medium mb-2">
+        {nearbySchools.length === 0
+          ? `No schools within ${proximity.radiusMiles} mi of ${proximity.label}`
+          : `${nearbySchools.length} school${nearbySchools.length !== 1 ? 's' : ''} within ${proximity.radiusMiles} mi of ${proximity.label}`}
+      </p>
+      <div className="flex flex-col gap-3">
+        {nearbySchools.map((school) => (
+          <SchoolCard key={school.id} school={school} distanceMiles={school.distanceMiles} onSelect={onSelectSchool} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function NonProximityPanel({ filters, onSelectSchool }: Pick<FilterResultsProps, 'filters' | 'onSelectSchool'>) {
+  const { schools, loading } = useSchools(filters)
+
+  if (loading) return (
+    <div className="bg-white px-4 py-2 text-xs text-gray-500">
+      Loading…
+    </div>
+  )
+
+  return (
+    <div className="bg-white px-4 py-3 h-full">
+      <p className="text-xs text-gray-500 font-medium mb-2">
+        {schools.length === 0
+          ? 'No matching schools'
+          : `${schools.length} school${schools.length !== 1 ? 's' : ''} match your filters`}
+      </p>
+      <div className="flex flex-col gap-3">
+        {schools.map((school) => (
+          <SchoolCard key={school.id} school={school} onSelect={onSelectSchool} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default function FilterResults({ filters, onSelectSchool, onZoneResult }: FilterResultsProps) {
+  if (filters.proximity) {
+    return <ProximityPanel filters={filters} onSelectSchool={onSelectSchool} onZoneResult={onZoneResult} />
+  }
+  return <NonProximityPanel filters={filters} onSelectSchool={onSelectSchool} />
+}

--- a/src/hooks/useSchools.ts
+++ b/src/hooks/useSchools.ts
@@ -78,6 +78,8 @@ export function useSchools(filters: FilterState) {
 
     if (filters.proximity) {
       result.sort((a, b) => (a.distanceMiles ?? 0) - (b.distanceMiles ?? 0))
+    } else {
+      result.sort((a, b) => b.indexScore - a.indexScore)
     }
 
     return result


### PR DESCRIPTION
## Summary
- Replaces `ProximityResults` with `FilterResults`, which shows a matching-school list for any active filter (search, county, level, type, star rating), not just proximity
- Renders `MapView` exactly once to prevent remount when toggling map/table or when filter state changes; uses CSS visibility instead of conditional rendering
- Sorts non-proximity panel results by index score descending by default
- Fixes `FlyToSchool` zoom (14 → 12) to match `RecenterMap` so address search zoom isn't overridden when a school was previously selected

## Test plan
- [ ] Apply a non-proximity filter (e.g. star rating, search, county) in map view → panel appears on the left with count header and school cards
- [ ] Clear filters → panel disappears, map returns to full width
- [ ] Apply a proximity filter → zone/radius behavior still works correctly
- [ ] Switch between map and table views — no map remount/flicker
- [ ] Search an address while a school is selected → map flies to the searched address at zoom 12
- [ ] Mobile: panel stacks above map

🤖 Generated with [Claude Code](https://claude.com/claude-code)