### PR TITLE
fix: zone filter shows wrong markers with other filters

### DIFF
--- a/src/components/panel/FilterResults.tsx
+++ b/src/components/panel/FilterResults.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef } from 'react'
 import type { FilterState, School } from '@/types/school'
+import { DEFAULT_FILTERS } from '@/types/school'
 import { useSchools } from '@/hooks/useSchools'
 import { useSchoolZones } from '@/hooks/useSchoolZones'
 import { findSchoolZonesForPoint, type ZoneLookupResult } from '@/utils/findSchoolZones'
@@ -18,7 +19,7 @@ function ProximityPanel({ filters, onSelectSchool, onZoneResult }: FilterResults
   const proximity = filters.proximity!
   const isZone = proximity.radiusMiles === 0
 
-  const { schools: allSchools } = useSchools({ ...filters, proximity: null, zonedSchoolIds: [] }, { showAll: true })
+  const { schools: allSchools } = useSchools(DEFAULT_FILTERS, { showAll: true })
   const { geojson, loading: zonesLoading } = useSchoolZones(true)
   const [zoneResult, setZoneResult] = useState<ZoneLookupResult | null>(null)
   const onZoneResultRef = useRef(onZoneResult)

--- a/src/hooks/useSchools.ts
+++ b/src/hooks/useSchools.ts
@@ -81,8 +81,8 @@ export function useSchools(filters: FilterState, { showAll = false } = {}) {
           school.lng
         )
         if (distanceMiles > filters.proximity.radiusMiles) continue
-      } else if (filters.proximity && filters.proximity.radiusMiles === 0 && filters.zonedSchoolIds.length > 0) {
-        if (!filters.zonedSchoolIds.includes(school.id)) continue
+      } else if (filters.proximity && filters.proximity.radiusMiles === 0) {
+        if (filters.zonedSchoolIds.length === 0 || !filters.zonedSchoolIds.includes(school.id)) continue
       }
 
       result.push({ ...school, distanceMiles })


### PR DESCRIPTION
## Summary
- Fix zone filter being bypassed when `zonedSchoolIds` is empty, which caused non-zoned schools matching other filters (e.g., star ratings) to appear on the map
- Fix zone lookup to use the full unfiltered school list (`DEFAULT_FILTERS`) so zoned schools are always found regardless of other active filters

## Test plan
- [ ] Search an address to activate zone mode
- [ ] Add other filters (e.g., 5-star only) that exclude the zoned schools
- [ ] Confirm the map shows no markers instead of showing non-zoned schools
- [ ] Remove the extra filters — confirm zoned schools reappear
- [ ] `npm run build` passes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)