### PR TITLE
Add sort controls to mobile list view

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -70,30 +70,39 @@ export default function Home() {
       </header>
 
       {/* Filter bar */}
-      <div className="bg-white border-b border-gray-200 px-4 py-3 space-y-3 shrink-0">
+      <div className="bg-white border-b border-gray-200 px-4 py-3 sm:space-y-3 shrink-0">
         {/* Row 1: search + proximity + clear + view toggle */}
         <div className="flex items-center gap-3 flex-wrap">
-          <SchoolSearch
-            value={filters.search}
-            onChange={(search) => setFilters((f) => ({ ...f, search }))}
-          />
+          <div className="hidden sm:flex sm:flex-col sm:gap-1">
+            <span className="text-xs font-semibold text-gray-500 uppercase tracking-wide">School</span>
+            <SchoolSearch
+              value={filters.search}
+              onChange={(search) => setFilters((f) => ({ ...f, search }))}
+            />
+          </div>
 
-          <ProximitySearch
-            proximity={filters.proximity}
-            onChange={(proximity, county) => setFilters((f) => ({ ...f, proximity, county }))}
-          />
-          <div className="flex rounded-lg border border-gray-300 overflow-hidden text-sm shrink-0 ml-auto">
+          <div className="hidden sm:flex sm:flex-col sm:gap-1">
+            <span className="text-xs font-semibold text-gray-500 uppercase tracking-wide">Address</span>
+            <div className="flex items-center gap-3">
+              <ProximitySearch
+                proximity={filters.proximity}
+                onChange={(proximity, county) => setFilters((f) => ({ ...f, proximity, county }))}
+              />
+            </div>
+          </div>
+          <div className="flex rounded border border-gray-300 overflow-hidden shrink-0 ml-auto">
             <button
               onClick={() => setView('map')}
-              className={`px-3 py-1.5 transition-colors ${view === 'map' ? 'bg-blue-600 text-white' : 'bg-white text-gray-600 hover:bg-gray-50'}`}
+              className={`px-2.5 py-0.5 text-xs font-bold transition-colors ${view === 'map' ? 'bg-blue-600 text-white' : 'bg-white text-gray-600 hover:border-gray-400'}`}
             >
               Map
             </button>
             <button
               onClick={() => { setView('table'); setSelectedSchool(null) }}
-              className={`px-3 py-1.5 border-l border-gray-300 transition-colors ${view === 'table' ? 'bg-blue-600 text-white' : 'bg-white text-gray-600 hover:bg-gray-50'}`}
+              className={`px-2.5 py-0.5 text-xs font-bold border-l border-gray-300 transition-colors ${view === 'table' ? 'bg-blue-600 text-white' : 'bg-white text-gray-600 hover:border-gray-400'}`}
             >
-              Table
+              <span className="sm:hidden">List</span>
+              <span className="hidden sm:inline">Table</span>
             </button>
           </div>
         </div>
@@ -177,7 +186,18 @@ export default function Home() {
           </div>
         </div>
         <div className={view === 'table' ? 'h-full' : 'hidden'}>
-          <TableView filters={filters} onSelectSchool={handleSelectSchool} />
+          {/* Desktop: full table */}
+          <div className="hidden sm:block h-full">
+            <TableView filters={filters} onSelectSchool={handleSelectSchool} />
+          </div>
+          {/* Mobile: scrollable card list */}
+          <div className="sm:hidden h-full overflow-y-auto">
+            <FilterResults
+              filters={filters}
+              onSelectSchool={handleSelectSchool}
+              onZoneResult={(ids) => setFilters((f) => ({ ...f, zonedSchoolIds: ids }))}
+            />
+          </div>
         </div>
       </main>
     </div>

--- a/src/components/filters/FilterDrawer.tsx
+++ b/src/components/filters/FilterDrawer.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useEffect } from 'react'
 import type { FilterState } from '@/types/school'
+import SchoolSearch from './SchoolSearch'
+import ProximitySearch from './ProximitySearch'
 import CountyFilter from './CountyFilter'
 import LevelFilter from './LevelFilter'
 import TypeFilter from './TypeFilter'
@@ -34,8 +36,8 @@ export default function FilterDrawer({ filters, onChange, onClear, filterCount, 
       )}
 
       <div
-        className="fixed bottom-0 left-0 right-0 z-50 bg-white rounded-t-2xl shadow-xl sm:hidden flex flex-col overflow-hidden max-h-[85vh] transition-transform duration-300 ease-out"
-        style={{ transform: isOpen ? 'translateY(0)' : 'translateY(calc(100% - 4.5rem))' }}
+        className="fixed bottom-0 left-0 right-0 z-50 bg-white rounded-t-2xl sm:hidden flex flex-col overflow-hidden max-h-[85vh] transition-transform duration-300 ease-out"
+        style={{ transform: isOpen ? 'translateY(0)' : 'translateY(calc(100% - 4.5rem))', boxShadow: '0 -3px 10px rgba(0, 0, 0, 0.1)' }}
       >
         {/* Drag handle + header row */}
         <div
@@ -63,7 +65,7 @@ export default function FilterDrawer({ filters, onChange, onClear, filterCount, 
                 </svg>
               </button>
             ) : (
-              <span className="text-sm text-gray-600">{schoolCount} schools</span>
+              <span className="text-sm text-gray-600">{schoolCount === 0 ? 'No' : schoolCount} {schoolCount === 1 ? 'school' : 'schools'} matched</span>
             )}
           </div>
         </div>
@@ -72,6 +74,24 @@ export default function FilterDrawer({ filters, onChange, onClear, filterCount, 
 
         {/* Scrollable body */}
         <div className="overflow-y-auto px-4 py-4 space-y-6">
+
+          <section>
+            <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-3">School</p>
+            <SchoolSearch
+              value={filters.search}
+              onChange={(search) => onChange({ ...filters, search })}
+            />
+          </section>
+
+          <section>
+            <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-3">Address</p>
+            <div className="flex flex-wrap items-center gap-2">
+              <ProximitySearch
+                proximity={filters.proximity}
+                onChange={(proximity, county) => onChange({ ...filters, proximity: proximity ?? null, county: county ?? filters.county })}
+              />
+            </div>
+          </section>
 
           {filters.proximity && (
             <section>
@@ -131,7 +151,7 @@ export default function FilterDrawer({ filters, onChange, onClear, filterCount, 
             onClick={() => setIsOpen(false)}
             className="flex-1 py-2.5 text-sm font-semibold text-white bg-blue-600 rounded-lg hover:bg-blue-700 transition-colors"
           >
-            View {schoolCount} schools
+            View {schoolCount} {schoolCount === 1 ? 'School' : 'Schools'}
           </button>
         </div>
 

--- a/src/components/filters/ProximitySearch.tsx
+++ b/src/components/filters/ProximitySearch.tsx
@@ -65,7 +65,7 @@ export default function ProximitySearch({ proximity, onChange }: ProximitySearch
         onChange={(e) => setAddress(e.target.value)}
         onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
         disabled={searching}
-        className="border border-gray-300 rounded px-3 py-1.5 text-sm flex-1 min-w-[160px] max-w-xs focus:outline-none focus:ring-2 focus:ring-blue-400 disabled:opacity-50"
+        className="border border-gray-300 rounded px-3 py-1.5 text-sm flex-1 min-w-[160px] max-w-md focus:outline-none focus:ring-2 focus:ring-blue-400 disabled:opacity-50"
       />
       <button
         onClick={handleSearch}

--- a/src/components/filters/SchoolSearch.tsx
+++ b/src/components/filters/SchoolSearch.tsx
@@ -9,10 +9,10 @@ export default function SchoolSearch({ value, onChange }: SchoolSearchProps) {
   return (
     <input
       type="search"
-      placeholder="Search school name…"
+      placeholder="Search school…"
       value={value}
       onChange={(e) => onChange(e.target.value)}
-      className="border border-gray-300 rounded px-3 py-1.5 text-sm flex-1 min-w-40 max-w-xs focus:outline-none focus:ring-2 focus:ring-blue-400"
+      className="border border-gray-300 rounded px-3 py-1.5 text-sm flex-1 min-w-40 max-w-md focus:outline-none focus:ring-2 focus:ring-blue-400"
     />
   )
 }

--- a/src/components/panel/FilterResults.tsx
+++ b/src/components/panel/FilterResults.tsx
@@ -1,13 +1,66 @@
 'use client'
 
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useMemo } from 'react'
 import type { FilterState, School } from '@/types/school'
 import { DEFAULT_FILTERS } from '@/types/school'
 import { useSchools } from '@/hooks/useSchools'
 import { useSchoolZones } from '@/hooks/useSchoolZones'
 import { findSchoolZonesForPoint, type ZoneLookupResult } from '@/utils/findSchoolZones'
+import { haversineDistanceMiles } from '@/utils/haversine'
 import SchoolCard from './SchoolCard'
 
+type SortKey = 'name' | 'starRating' | 'indexScore' | 'distanceMiles'
+
+interface SortOption { label: string; value: SortKey }
+
+const BASE_OPTIONS: SortOption[] = [
+  { label: 'Name', value: 'name' },
+  { label: 'Score', value: 'indexScore' },
+]
+
+const DISTANCE_OPTION: SortOption = { label: 'Distance', value: 'distanceMiles' }
+
+function SortBar({ sortKey, sortAsc, options, onSortKeyChange, onSortAscChange }: {
+  sortKey: SortKey
+  sortAsc: boolean
+  options: SortOption[]
+  onSortKeyChange: (k: SortKey) => void
+  onSortAscChange: (asc: boolean) => void
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <select
+        className="text-xs font-bold border border-gray-300 rounded px-1.5 py-0.5"
+        value={sortKey}
+        onChange={(e) => onSortKeyChange(e.target.value as SortKey)}
+      >
+        {options.map((o) => (
+          <option key={o.value} value={o.value}>{o.label}</option>
+        ))}
+      </select>
+      <button
+        className="text-xs font-bold border border-gray-300 rounded px-1.5 py-0.5"
+        onClick={() => onSortAscChange(!sortAsc)}
+        title={sortAsc ? 'Ascending' : 'Descending'}
+      >
+        {sortAsc ? '↑' : '↓'}
+      </button>
+    </div>
+  )
+}
+
+function sortSchools<T extends School>(schools: T[], sortKey: SortKey, sortAsc: boolean): T[] {
+  return [...schools].sort((a, b) => {
+    const av = (a as Record<string, unknown>)[sortKey]
+    const bv = (b as Record<string, unknown>)[sortKey]
+    if (av == null && bv == null) return 0
+    if (av == null) return 1
+    if (bv == null) return -1
+    if (av < bv) return sortAsc ? -1 : 1
+    if (av > bv) return sortAsc ? 1 : -1
+    return 0
+  })
+}
 
 interface FilterResultsProps {
   filters: FilterState
@@ -35,6 +88,14 @@ function ProximityPanel({ filters, onSelectSchool, onZoneResult }: FilterResults
 
   const { schools: nearbySchools, loading: nearbyLoading } = useSchools(filters)
 
+  const [sortKey, setSortKey] = useState<SortKey>('distanceMiles')
+  const [sortAsc, setSortAsc] = useState(true)
+
+  const sortedNearby = useMemo(
+    () => sortSchools(nearbySchools, sortKey, sortAsc),
+    [nearbySchools, sortKey, sortAsc]
+  )
+
   const loading = isZone ? zonesLoading : nearbyLoading
 
   if (loading) return (
@@ -45,27 +106,38 @@ function ProximityPanel({ filters, onSelectSchool, onZoneResult }: FilterResults
 
   if (isZone) {
     if (!zoneResult || (!zoneResult.Elementary && !zoneResult.Middle && !zoneResult.High)) return null
+    const zonedSchools = [zoneResult.Elementary, zoneResult.Middle, zoneResult.High].filter(Boolean) as School[]
     return (
       <div className="bg-white px-4 py-3 h-full">
-        <p className="text-xs text-gray-500 font-medium mb-2">Schools zoned for {proximity.label}</p>
+        <p className="text-xs text-gray-500 font-medium mb-2">
+          {zonedSchools.length} {zonedSchools.length === 1 ? 'school' : 'schools'} matched
+        </p>
         <div className="flex flex-col gap-3">
-          {zoneResult.Elementary && <SchoolCard school={zoneResult.Elementary} onSelect={onSelectSchool} />}
-          {zoneResult.Middle && <SchoolCard school={zoneResult.Middle} onSelect={onSelectSchool} />}
-          {zoneResult.High && <SchoolCard school={zoneResult.High} onSelect={onSelectSchool} />}
+          {zonedSchools.map((s) => (
+            <SchoolCard
+              key={s.id}
+              school={s}
+              distanceMiles={s.lat != null && s.lng != null ? haversineDistanceMiles(proximity.lat, proximity.lng, s.lat, s.lng) : null}
+              onSelect={onSelectSchool}
+            />
+          ))}
         </div>
       </div>
     )
   }
 
+  const radiusOptions = [...BASE_OPTIONS, DISTANCE_OPTION]
+
   return (
     <div className="bg-white px-4 py-3 h-full">
-      <p className="text-xs text-gray-500 font-medium mb-2">
-        {nearbySchools.length === 0
-          ? `No schools within ${proximity.radiusMiles} mi of ${proximity.label}`
-          : `${nearbySchools.length} school${nearbySchools.length !== 1 ? 's' : ''} within ${proximity.radiusMiles} mi of ${proximity.label}`}
-      </p>
+      <div className="flex items-center justify-between mb-2">
+        <p className="text-xs text-gray-500 font-medium">
+{nearbySchools.length === 0 ? 'No' : nearbySchools.length} {nearbySchools.length === 1 ? 'school' : 'schools'} matched
+        </p>
+        <SortBar sortKey={sortKey} sortAsc={sortAsc} options={radiusOptions} onSortKeyChange={setSortKey} onSortAscChange={setSortAsc} />
+      </div>
       <div className="flex flex-col gap-3">
-        {nearbySchools.map((school) => (
+        {sortedNearby.map((school) => (
           <SchoolCard key={school.id} school={school} distanceMiles={school.distanceMiles} onSelect={onSelectSchool} />
         ))}
       </div>
@@ -76,6 +148,14 @@ function ProximityPanel({ filters, onSelectSchool, onZoneResult }: FilterResults
 function NonProximityPanel({ filters, onSelectSchool }: Pick<FilterResultsProps, 'filters' | 'onSelectSchool'>) {
   const { schools, loading } = useSchools(filters)
 
+  const [sortKey, setSortKey] = useState<SortKey>('indexScore')
+  const [sortAsc, setSortAsc] = useState(false)
+
+  const sorted = useMemo(
+    () => sortSchools(schools, sortKey, sortAsc),
+    [schools, sortKey, sortAsc]
+  )
+
   if (loading) return (
     <div className="bg-white px-4 py-2 text-xs text-gray-500">
       Loading…
@@ -84,13 +164,14 @@ function NonProximityPanel({ filters, onSelectSchool }: Pick<FilterResultsProps,
 
   return (
     <div className="bg-white px-4 py-3 h-full">
-      <p className="text-xs text-gray-500 font-medium mb-2">
-        {schools.length === 0
-          ? 'No matching schools'
-          : `${schools.length} school${schools.length !== 1 ? 's' : ''} match your filters`}
-      </p>
+      <div className="flex items-center justify-between mb-2">
+        <p className="text-xs text-gray-500 font-medium">
+{schools.length === 0 ? 'No' : schools.length} {schools.length === 1 ? 'school' : 'schools'} matched
+        </p>
+        <SortBar sortKey={sortKey} sortAsc={sortAsc} options={BASE_OPTIONS} onSortKeyChange={setSortKey} onSortAscChange={setSortAsc} />
+      </div>
       <div className="flex flex-col gap-3">
-        {schools.map((school) => (
+        {sorted.map((school) => (
           <SchoolCard key={school.id} school={school} onSelect={onSelectSchool} />
         ))}
       </div>

--- a/src/components/panel/SchoolCard.tsx
+++ b/src/components/panel/SchoolCard.tsx
@@ -19,15 +19,18 @@ export default function SchoolCard({ school, distanceMiles, onSelect }: SchoolCa
       onClick={() => onSelect(school)}
       className="rounded-lg border border-gray-200 p-3 bg-white text-left hover:border-blue-400 hover:shadow-sm transition-colors"
     >
+      {/* Title row */}
+      <div className="flex items-baseline gap-2 mb-1">
+        <p className="font-semibold text-gray-900 text-sm leading-tight">{school.name}</p>
+        {distanceMiles != null && (
+          <span className="text-xs text-gray-400 shrink-0">{distanceMiles.toFixed(1)} mi</span>
+        )}
+      </div>
+
+      {/* Details + metrics */}
       <div className="flex gap-4 items-start">
         <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2">
-            <p className="font-semibold text-gray-900 text-sm leading-tight truncate">{school.name}</p>
-            {distanceMiles != null && (
-              <span className="text-xs text-gray-400 shrink-0">{distanceMiles.toFixed(1)} mi</span>
-            )}
-          </div>
-          <p className="text-xs text-gray-500 mt-0.5">{school.level} · {school.type}</p>
+          <p className="text-xs text-gray-500">{school.level} · {school.type}</p>
           {school.address && school.city && (
             <a
               href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(`${school.name}, ${school.address}, ${school.city}, NV ${school.zip ?? ''}`.trim())}`}

--- a/src/components/table/TableView.tsx
+++ b/src/components/table/TableView.tsx
@@ -116,7 +116,7 @@ export default function TableView({ filters, onSelectSchool }: TableViewProps) {
             {pageSlice.length === 0 ? (
               <tr>
                 <td colSpan={colCount} className="px-4 py-8 text-center text-gray-400">
-                  No schools match your filters.
+                  No schools matched
                 </td>
               </tr>
             ) : (
@@ -176,7 +176,7 @@ export default function TableView({ filters, onSelectSchool }: TableViewProps) {
           </div>
           {/* Desktop: count label on left. Hidden on mobile. */}
           <span className="hidden sm:inline text-gray-500">
-            {sorted.length} schools{totalPages > 1 && ` · Page ${page + 1} of ${totalPages}`}
+            {sorted.length === 0 ? 'No' : sorted.length} {sorted.length === 1 ? 'school' : 'schools'} matched{totalPages > 1 && ` · Page ${page + 1} of ${totalPages}`}
           </span>
           {/* Right: size selector (desktop only) + Prev/Next */}
           <div className="flex items-center gap-3">


### PR DESCRIPTION
## Summary
- Add sort dropdown (Name, Score, Distance) and ascending/descending toggle to the mobile list view (FilterResults)
- ProximityPanel defaults to Distance ascending; NonProximityPanel defaults to Score descending
- Zone mode keeps fixed Elementary/Middle/High order with no sort controls
- Includes UI refinements to FilterDrawer, ProximitySearch, SchoolSearch, and SchoolCard

## Test plan
- [ ] Switch to List view on mobile, verify sort dropdown appears with Name/Score options
- [ ] Activate proximity search, verify Distance option appears in dropdown
- [ ] Toggle ascending/descending, verify list order reverses
- [ ] Zone search (0 radius) should not show sort controls
- [ ] Desktop side panel should also show the sort controls
- [ ] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)