### PR TITLE
feat: show all schools by default when no filters active

### DIFF
--- a/src/components/panel/FilterResults.tsx
+++ b/src/components/panel/FilterResults.tsx
@@ -72,7 +72,7 @@ function ProximityPanel({ filters, onSelectSchool, onZoneResult }: FilterResults
   const proximity = filters.proximity!
   const isZone = proximity.radiusMiles === 0
 
-  const { schools: allSchools } = useSchools(DEFAULT_FILTERS, { showAll: true })
+  const { schools: allSchools } = useSchools(DEFAULT_FILTERS)
   const { geojson, loading: zonesLoading } = useSchoolZones(true)
   const [zoneResult, setZoneResult] = useState<ZoneLookupResult | null>(null)
   const onZoneResultRef = useRef(onZoneResult)

--- a/src/hooks/useSchools.ts
+++ b/src/hooks/useSchools.ts
@@ -4,7 +4,7 @@ import { useState, useEffect, useMemo } from 'react'
 import type { School, FilterState, SchoolWithDistance } from '@/types/school'
 import { haversineDistanceMiles } from '@/utils/haversine'
 
-export function useSchools(filters: FilterState, { showAll = false } = {}) {
+export function useSchools(filters: FilterState) {
   const [schools, setSchools] = useState<School[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -27,18 +27,6 @@ export function useSchools(filters: FilterState, { showAll = false } = {}) {
   }, [])
 
   const filtered = useMemo(() => {
-    const hasFilters =
-      filters.search !== '' ||
-      filters.schoolTypes.length > 0 ||
-      filters.schoolLevels.length > 0 ||
-      filters.starRatings.length > 0 ||
-      filters.county !== null ||
-      filters.proximity !== null ||
-      filters.zonedSchoolIds.length > 0
-
-
-    if (!showAll && !hasFilters) return []
-
     const result: SchoolWithDistance[] = []
 
     for (const school of schools) {


### PR DESCRIPTION
## Summary
- Remove the early-return guard in `useSchools` that returned an empty array when no filters were selected
- All schools now display on initial page load across map, table, and list views
- Clean up the unused `showAll` parameter and `hasFilters` variable

## Test plan
- [ ] Run `npm run dev` and confirm all schools appear on the map and list with no filters selected
- [ ] Apply filters (star rating, school type, search) and confirm results narrow correctly
- [ ] Clear all filters and confirm all schools reappear
- [ ] Verify proximity/zone search still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)