### PR TITLE
feat: add zone boundaries with level-based z-ordering

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -182,7 +182,7 @@ export default function Home() {
             </div>
           )}
           <div className="flex-1 min-h-0">
-            <MapView filters={filters} selectedSchool={selectedSchool} isVisible={view === 'map'} />
+            <MapView filters={filters} selectedSchool={selectedSchool} isVisible={view === 'map'} onSelectSchool={handleSelectSchool} />
           </div>
         </div>
         <div className={view === 'table' ? 'h-full' : 'hidden'}>

--- a/src/components/map/MapInner.tsx
+++ b/src/components/map/MapInner.tsx
@@ -2,16 +2,18 @@
 
 import 'leaflet/dist/leaflet.css'
 import { MapContainer, TileLayer, Marker, Circle, useMap } from 'react-leaflet'
-import { useEffect } from 'react'
+import { useCallback, useEffect } from 'react'
 import { useSchools } from '@/hooks/useSchools'
 import { createUserLocationIcon } from '@/utils/markerColors'
 import type { FilterState, School } from '@/types/school'
 import SchoolMarker from './SchoolMarker'
+import ZoneBoundaries from './ZoneBoundaries'
 
 interface MapInnerProps {
   filters: FilterState
   selectedSchool?: School | null
   isVisible?: boolean
+  onSelectSchool?: (school: School) => void
 }
 
 const NEVADA_CENTER: [number, number] = [38.8, -116.8]
@@ -51,8 +53,12 @@ function FlyToSchool({ school }: { school: School }) {
   const map = useMap()
   useEffect(() => {
     if (school.lat && school.lng) {
-      map.invalidateSize()
-      map.flyTo([school.lat, school.lng], 12)
+      const target: [number, number] = [school.lat, school.lng]
+      if (map.getZoom() === 12) {
+        map.panTo(target, { animate: true, duration: 0.5 })
+      } else {
+        map.flyTo(target, 12)
+      }
     }
   }, [school, map])
   return null
@@ -82,8 +88,14 @@ function CountyFocus({ county }: { county: string | null }) {
   return null
 }
 
-export default function MapInner({ filters, selectedSchool, isVisible }: MapInnerProps) {
+export default function MapInner({ filters, selectedSchool, isVisible, onSelectSchool }: MapInnerProps) {
   const { schools, loading, error } = useSchools(filters)
+
+  const handleZoneClick = useCallback((schoolId: string) => {
+    if (!onSelectSchool) return
+    const school = schools.find(s => s.id === schoolId)
+    if (school) onSelectSchool(school)
+  }, [schools, onSelectSchool])
   const proximity = filters.proximity
 
   if (loading) {
@@ -135,8 +147,11 @@ export default function MapInner({ filters, selectedSchool, isVisible }: MapInne
           />
         </>
       )}
+      {proximity && proximity.radiusMiles === 0 && filters.zonedSchoolIds.length > 0 && (
+        <ZoneBoundaries zonedSchoolIds={filters.zonedSchoolIds} selectedSchoolId={selectedSchool?.id ?? null} onZoneClick={handleZoneClick} />
+      )}
       {schools.map((school) => (
-        <SchoolMarker key={school.id} school={school} isSelected={selectedSchool?.id === school.id} />
+        <SchoolMarker key={school.id} school={school} isSelected={selectedSchool?.id === school.id} onSelect={onSelectSchool} />
       ))}
     </MapContainer>
   )

--- a/src/components/map/MapView.tsx
+++ b/src/components/map/MapView.tsx
@@ -14,12 +14,13 @@ interface MapViewProps {
   filters: FilterState
   selectedSchool?: School | null
   isVisible?: boolean
+  onSelectSchool?: (school: School) => void
 }
 
-export default function MapView({ filters, selectedSchool, isVisible }: MapViewProps) {
+export default function MapView({ filters, selectedSchool, isVisible, onSelectSchool }: MapViewProps) {
   return (
     <div className="w-full h-full">
-      <MapInner filters={filters} selectedSchool={selectedSchool} isVisible={isVisible} />
+      <MapInner filters={filters} selectedSchool={selectedSchool} isVisible={isVisible} onSelectSchool={onSelectSchool} />
     </div>
   )
 }

--- a/src/components/map/SchoolMarker.tsx
+++ b/src/components/map/SchoolMarker.tsx
@@ -9,9 +9,10 @@ import type { SchoolWithDistance } from '@/types/school'
 interface SchoolMarkerProps {
   school: SchoolWithDistance
   isSelected?: boolean
+  onSelect?: (school: SchoolWithDistance) => void
 }
 
-export default function SchoolMarker({ school, isSelected }: SchoolMarkerProps) {
+export default function SchoolMarker({ school, isSelected, onSelect }: SchoolMarkerProps) {
   const icon = createMarkerIcon(school.starRating)
   const markerRef = useRef<L.Marker>(null)
 
@@ -24,7 +25,7 @@ export default function SchoolMarker({ school, isSelected }: SchoolMarkerProps) 
   if (school.lat === null || school.lng === null) return null
 
   return (
-    <Marker ref={markerRef} position={[school.lat, school.lng]} icon={icon}>
+    <Marker ref={markerRef} position={[school.lat, school.lng]} icon={icon} eventHandlers={{ click: () => onSelect?.(school) }}>
       <Popup>
         <div className="min-w-[220px]">
           <div className="flex items-baseline justify-between gap-2">

--- a/src/components/map/ZoneBoundaries.tsx
+++ b/src/components/map/ZoneBoundaries.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import { useCallback, useRef } from 'react'
+import { GeoJSON } from 'react-leaflet'
+import L from 'leaflet'
+import { useSchoolZones } from '@/hooks/useSchoolZones'
+import { getZoneBoundaryColor } from '@/utils/markerColors'
+import type { SchoolLevel } from '@/types/school'
+
+interface ZoneBoundariesProps {
+  zonedSchoolIds: string[]
+  selectedSchoolId?: string | null
+  onZoneClick?: (schoolId: string) => void
+}
+
+function getFeatureStyle(feature: GeoJSON.Feature | undefined, selectedSchoolId: string | null | undefined) {
+  const level = feature?.properties?.level as SchoolLevel
+  const color = getZoneBoundaryColor(level)
+  const isSelected = feature?.properties?.schoolId === selectedSchoolId
+  return {
+    color,
+    fillColor: color,
+    fillOpacity: isSelected ? 0.25 : 0.10,
+    weight: isSelected ? 3 : 2,
+  }
+}
+
+export default function ZoneBoundaries({ zonedSchoolIds, selectedSchoolId, onZoneClick }: ZoneBoundariesProps) {
+  const { geojson } = useSchoolZones(true)
+  const geoJsonRef = useRef<L.GeoJSON | null>(null)
+  const canvasRenderer = useRef(L.canvas({ padding: 0.5 }))
+
+  const styleFn = useCallback(
+    (feature: GeoJSON.Feature | undefined) => getFeatureStyle(feature, selectedSchoolId),
+    [selectedSchoolId]
+  )
+
+  if (!geojson) return null
+
+  const idSet = new Set(zonedSchoolIds)
+  const fc = geojson as GeoJSON.FeatureCollection
+  const LEVEL_ORDER: Record<string, number> = { High: 0, Middle: 1, Elementary: 2 }
+  const filtered: GeoJSON.FeatureCollection = {
+    type: 'FeatureCollection',
+    features: fc.features.filter(f => idSet.has(f.properties?.schoolId)),
+  }
+  filtered.features.sort((a, b) =>
+    (LEVEL_ORDER[a.properties?.level] ?? 1) - (LEVEL_ORDER[b.properties?.level] ?? 1)
+  )
+
+  if (filtered.features.length === 0) return null
+
+  return (
+    <GeoJSON
+      ref={geoJsonRef}
+      key={zonedSchoolIds.join(',')}
+      data={filtered}
+      {...{ renderer: canvasRenderer.current } as Record<string, unknown>}
+      onEachFeature={(feature, layer) => {
+        if (onZoneClick) {
+          layer.on('click', () => {
+            const schoolId = feature.properties?.schoolId
+            if (schoolId) onZoneClick(schoolId)
+          })
+        }
+      }}
+      style={styleFn}
+    />
+  )
+}

--- a/src/utils/markerColors.ts
+++ b/src/utils/markerColors.ts
@@ -1,4 +1,4 @@
-import type { StarRating } from '@/types/school'
+import type { SchoolLevel, StarRating } from '@/types/school'
 
 const STAR_COLORS: Record<StarRating, string> = {
   1: '#ef4444', // red
@@ -29,6 +29,16 @@ export function createUserLocationIcon() {
     iconAnchor: [9, 9],
     popupAnchor: [0, -12],
   })
+}
+
+const ZONE_BOUNDARY_COLORS: Record<SchoolLevel, string> = {
+  Elementary: '#3b82f6', // blue
+  Middle: '#f59e0b',     // amber
+  High: '#10b981',       // emerald
+}
+
+export function getZoneBoundaryColor(level: SchoolLevel): string {
+  return ZONE_BOUNDARY_COLORS[level] ?? '#6b7280'
 }
 
 export function createMarkerIcon(starRating: StarRating | null) {


### PR DESCRIPTION
## Summary
- Add `ZoneBoundaries` component that renders school zone polygons on the map using GeoJSON and Canvas renderer
- Sort zone features by school level (High → Middle → Elementary) so smaller elementary zones render on top and remain clickable when overlapping larger zones
- Wire zone boundaries into `MapInner` with click handling and color-coded styling per level

## Test plan
- [ ] Run `npm run dev`, enter an address, set 0-mile radius to activate zone mode
- [ ] Verify zone boundary polygons appear on the map color-coded by level
- [ ] Where zones overlap, confirm elementary zones are clickable on top of high school zones
- [ ] Run `npm run build` — no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)