### PR TITLE
chore: simplify metadata descriptions and add about page to sitemap

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -5,4 +5,9 @@
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
+  <url>
+    <loc>https://nevadaschoolratings.com/about</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
 </urlset>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,12 +7,14 @@ export const metadata: Metadata = {
   metadataBase: new URL('https://nevadaschoolratings.com'),
   title: 'Nevada School Ratings',
   description:
-    'Explore Nevada school star ratings, performance data, and school zone information. Search, filter, and compare schools across the state with interactive maps and tables.',
+    'An interactive map for visualizing Nevada school ratings.',
   keywords: [
     'Nevada school ratings',
+    'Nevada school map',
     'Nevada school star ratings',
     'Nevada school performance',
     'NV school ratings',
+    'NV school map',
     'Nevada education data',
     'school star ratings Nevada',
     'Nevada school zones',
@@ -28,7 +30,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: 'Nevada School Ratings — Star Ratings & Performance Data',
     description:
-      'Explore Nevada school star ratings, performance data, and school zone information. Search, filter, and compare schools across the state.',
+      'An interactive map for visualizing Nevada school ratings.',
     type: 'website',
     url: 'https://nevadaschoolratings.com',
     siteName: 'Nevada School Ratings',
@@ -37,7 +39,7 @@ export const metadata: Metadata = {
     card: 'summary',
     title: 'Nevada School Ratings — Star Ratings & Performance Data',
     description:
-      'Explore Nevada school star ratings, performance data, and school zone information. Search, filter, and compare schools across the state.',
+      'An interactive map for visualizing Nevada school ratings.',
   },
 }
 
@@ -54,13 +56,13 @@ const jsonLd = {
       name: 'Nevada School Ratings',
       url: 'https://nevadaschoolratings.com',
       description:
-        'Explore Nevada school star ratings, performance data, and school zone information.',
+        'An interactive map for visualizing Nevada school ratings.',
     },
     {
       '@type': 'Dataset',
       name: 'Nevada School Performance Ratings',
       description:
-        'Star ratings and performance data for public, charter, and alternative schools across Nevada.',
+        'Star ratings and performance data for Nevada public schools.',
       url: 'https://nevadaschoolratings.com',
       keywords: [
         'Nevada schools',


### PR DESCRIPTION
## Summary
- Simplify metadata descriptions across layout.tsx (page description, OpenGraph, Twitter card, JSON-LD)
- Add `/about` page to sitemap.xml so it gets indexed by search engines

## Test plan
- [ ] Verify site builds successfully (`npm run build`)
- [ ] Check meta tags in page source
- [ ] Validate sitemap.xml includes both `/` and `/about`

🤖 Generated with [Claude Code](https://claude.com/claude-code)