### PR TITLE
feat: encode filter state in URL for shareable links

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import { useCallback, useState } from 'react'
+import { Suspense, useCallback, useEffect, useRef, useState } from 'react'
 import Link from 'next/link'
+import { useRouter, useSearchParams } from 'next/navigation'
 import type { FilterState, School } from '@/types/school'
-import { DEFAULT_FILTERS } from '@/types/school'
 import SchoolSearch from '@/components/filters/SchoolSearch'
 import CountyFilter from '@/components/filters/CountyFilter'
 import LevelFilter from '@/components/filters/LevelFilter'
@@ -16,13 +16,39 @@ import { useSchools } from '@/hooks/useSchools'
 import MapView from '@/components/map/MapView'
 import TableView from '@/components/table/TableView'
 import FilterResults from '@/components/panel/FilterResults'
+import { parseFilters, serializeFilters } from '@/utils/filterParams'
 
+function HomeContent() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
 
-export default function Home() {
   const [view, setView] = useState<'map' | 'table'>('map')
-  const [filters, setFilters] = useState<FilterState>(DEFAULT_FILTERS)
+  const [filters, setFilters] = useState<FilterState>(() => parseFilters(searchParams))
   const [selectedSchool, setSelectedSchool] = useState<School | null>(null)
   const [addressError, setAddressError] = useState<string | null>(null)
+  const isPopState = useRef(false)
+
+  useEffect(() => {
+    function handlePopState() {
+      isPopState.current = true
+      setFilters(parseFilters(new URLSearchParams(window.location.search)))
+    }
+    window.addEventListener('popstate', handlePopState)
+    return () => window.removeEventListener('popstate', handlePopState)
+  }, [])
+
+  useEffect(() => {
+    if (isPopState.current) {
+      isPopState.current = false
+      return
+    }
+    const params = serializeFilters(filters)
+    const qs = params.toString()
+    const timer = setTimeout(() => {
+      router.push(qs ? `?${qs}` : '?', { scroll: false })
+    }, 300)
+    return () => clearTimeout(timer)
+  }, [filters, router])
 
   const handleSelectSchool = useCallback((school: School) => {
     setSelectedSchool(school)
@@ -47,7 +73,7 @@ export default function Home() {
     (filters.proximity !== null ? 1 : 0)
 
   function clearFilters() {
-    setFilters(DEFAULT_FILTERS)
+    setFilters(parseFilters(new URLSearchParams()))
   }
 
   return (
@@ -205,5 +231,13 @@ export default function Home() {
         </div>
       </main>
     </div>
+  )
+}
+
+export default function Home() {
+  return (
+    <Suspense fallback={null}>
+      <HomeContent />
+    </Suspense>
   )
 }

--- a/src/components/filters/ProximitySearch.tsx
+++ b/src/components/filters/ProximitySearch.tsx
@@ -11,7 +11,7 @@ interface ProximitySearchProps {
 }
 
 export default function ProximitySearch({ proximity, onChange, onError }: ProximitySearchProps) {
-  const [address, setAddress] = useState('')
+  const [address, setAddress] = useState(proximity?.label ?? '')
   const [searching, setSearching] = useState(false)
   const [error, setError] = useState<string | null>(null)
 

--- a/src/utils/filterParams.ts
+++ b/src/utils/filterParams.ts
@@ -1,0 +1,70 @@
+import type { FilterState, SchoolType, SchoolLevel, StarRating } from '@/types/school'
+import { DEFAULT_FILTERS } from '@/types/school'
+
+const VALID_TYPES = new Set<string>(['District', 'Charter', 'Magnet'])
+const VALID_LEVELS = new Set<string>(['Elementary', 'Middle', 'High'])
+const VALID_STARS = new Set<number>([1, 2, 3, 4, 5])
+
+export function serializeFilters(filters: FilterState): URLSearchParams {
+  const params = new URLSearchParams()
+
+  if (filters.search) params.set('q', filters.search)
+  if (filters.schoolTypes.length) params.set('types', filters.schoolTypes.join(','))
+  if (filters.schoolLevels.length) params.set('levels', filters.schoolLevels.join(','))
+  if (filters.starRatings.length) {
+    params.set('stars', filters.starRatings.map(s => (s === null ? '0' : String(s))).join(','))
+  }
+  if (filters.county) params.set('county', filters.county)
+  if (filters.proximity) {
+    params.set('lat', String(filters.proximity.lat))
+    params.set('lng', String(filters.proximity.lng))
+    params.set('radius', String(filters.proximity.radiusMiles))
+    params.set('label', filters.proximity.label)
+  }
+
+  return params
+}
+
+export function parseFilters(params: URLSearchParams): FilterState {
+  const search = params.get('q') ?? ''
+
+  const typesStr = params.get('types')
+  const schoolTypes = typesStr
+    ? (typesStr.split(',').filter(t => VALID_TYPES.has(t)) as SchoolType[])
+    : []
+
+  const levelsStr = params.get('levels')
+  const schoolLevels = levelsStr
+    ? (levelsStr.split(',').filter(l => VALID_LEVELS.has(l)) as SchoolLevel[])
+    : []
+
+  const starsStr = params.get('stars')
+  const starRatings: (StarRating | null)[] = starsStr
+    ? starsStr.split(',').flatMap(s => {
+        if (s === '0') return [null]
+        const n = parseInt(s, 10)
+        return VALID_STARS.has(n) ? [(n as StarRating)] : []
+      })
+    : []
+
+  const county = params.get('county')
+
+  const latStr = params.get('lat')
+  const lngStr = params.get('lng')
+  const radiusStr = params.get('radius')
+  const label = params.get('label') ?? ''
+  const proximity =
+    latStr && lngStr && radiusStr
+      ? { lat: Number(latStr), lng: Number(lngStr), radiusMiles: Number(radiusStr), label }
+      : null
+
+  return {
+    ...DEFAULT_FILTERS,
+    search,
+    schoolTypes,
+    schoolLevels,
+    starRatings,
+    county,
+    proximity,
+  }
+}


### PR DESCRIPTION
Closes #25

## Summary
- Add `src/utils/filterParams.ts` with `serializeFilters` / `parseFilters` to convert `FilterState` ↔ URL query params (`q`, `types`, `levels`, `stars`, `county`, `lat`, `lng`, `radius`, `label`)
- Wrap `page.tsx` home content in `<Suspense>` (required by Next.js for `useSearchParams`) and initialize filter state from URL on load; debounce-push URL updates on filter changes (300ms); listen to `popstate` for back/forward navigation
- Pre-fill the address input in `ProximitySearch` from `proximity.label` so shared proximity URLs show the original address

## Test plan
- [ ] Set filters (county, level, type, stars) — URL updates within ~300ms
- [ ] Copy URL, open in new tab — all filters restored
- [ ] Search an address with a radius — copy URL, open in new tab — address input pre-filled, proximity circle appears
- [ ] Click Clear All — URL params removed
- [ ] Change filters several times, press browser back button — navigates through prior filter states
- [ ] `npm run build` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)