### PR TITLE
Scope proficiency deltas to each school's county in proximity search

### DIFF
--- a/src/components/map/CountyClusterMarkers.tsx
+++ b/src/components/map/CountyClusterMarkers.tsx
@@ -4,7 +4,7 @@ import { useMemo, useState, useCallback } from 'react'
 import { useMapEvents } from 'react-leaflet'
 import SchoolMarker from './SchoolMarker'
 import CountyPolygons from './CountyPolygons'
-import type { School, SchoolWithDistance } from '@/types/school'
+import type { FilterState, School, SchoolWithDistance } from '@/types/school'
 
 const CLUSTER_ZOOM_THRESHOLD = 9
 
@@ -14,7 +14,8 @@ interface CountyClusterMarkersProps {
   onSelectSchool?: (school: School) => void
   forceIndividual?: boolean
   onCountyFilter?: (county: string) => void
-  avgScope: string
+  // Picks the scope the popup deltas compare against — see schoolDeltaAverage.
+  filters: FilterState
 }
 
 export default function CountyClusterMarkers({
@@ -23,7 +24,7 @@ export default function CountyClusterMarkers({
   onSelectSchool,
   forceIndividual,
   onCountyFilter,
-  avgScope,
+  filters,
 }: CountyClusterMarkersProps) {
   const map = useMapEvents({
     zoomend: () => setZoom(map.getZoom()),
@@ -62,7 +63,7 @@ export default function CountyClusterMarkers({
             school={school}
             isSelected={selectedSchool?.id === school.id}
             onSelect={onSelectSchool}
-            avgScope={avgScope}
+            filters={filters}
           />
         ))}
       </>

--- a/src/components/map/MapInner.tsx
+++ b/src/components/map/MapInner.tsx
@@ -6,7 +6,6 @@ import { useCallback, useEffect } from 'react'
 import { useSchools } from '@/hooks/useSchools'
 import { createUserLocationIcon } from '@/utils/markerColors'
 import { COUNTY_VIEWS } from '@/utils/countyViews'
-import { STATE_SCOPE } from '@/utils/countyAverages'
 import type { FilterState, School } from '@/types/school'
 import ZoneBoundaries from './ZoneBoundaries'
 import CountyClusterMarkers from './CountyClusterMarkers'
@@ -138,7 +137,7 @@ export default function MapInner({ filters, selectedSchool, isVisible, onSelectS
         onSelectSchool={onSelectSchool}
         forceIndividual={!!filters.county || !!filters.proximity}
         onCountyFilter={onCountyFilter}
-        avgScope={filters.county ?? STATE_SCOPE}
+        filters={filters}
       />
     </MapContainer>
   )

--- a/src/components/map/SchoolMarker.tsx
+++ b/src/components/map/SchoolMarker.tsx
@@ -4,23 +4,23 @@ import React, { useEffect, useRef } from 'react'
 import { Marker, Popup } from 'react-leaflet'
 import type L from 'leaflet'
 import { createMarkerIcon, getMarkerColor } from '@/utils/markerColors'
-import type { SchoolWithDistance } from '@/types/school'
+import type { FilterState, SchoolWithDistance } from '@/types/school'
 import { useCountyAverages } from '@/hooks/useCountyAverages'
-import { formatDelta, deltaColor, countyLevelKey } from '@/utils/countyAverages'
+import { formatDelta, deltaColor, schoolDeltaAverage } from '@/utils/countyAverages'
 
 interface SchoolMarkerProps {
   school: SchoolWithDistance
   isSelected?: boolean
   onSelect?: (school: SchoolWithDistance) => void
-  // Scope the deltas compare against — the selected county, or STATE_SCOPE when none.
-  avgScope: string
+  // Picks the scope the deltas compare against — see schoolDeltaAverage.
+  filters: FilterState
 }
 
-export default React.memo(function SchoolMarker({ school, isSelected, onSelect, avgScope }: SchoolMarkerProps) {
+export default React.memo(function SchoolMarker({ school, isSelected, onSelect, filters }: SchoolMarkerProps) {
   const icon = createMarkerIcon(school.starRating)
   const markerRef = useRef<L.Marker>(null)
   const countyAvgMap = useCountyAverages()
-  const countyAvg = countyAvgMap ? countyAvgMap.get(countyLevelKey(avgScope, school.level)) ?? null : null
+  const countyAvg = schoolDeltaAverage(countyAvgMap, school, filters)
   // NDE only publishes county proficiency, so those are the only deltas we can show.
   const elaDelta = countyAvg ? formatDelta(typeof school.elaProficient === 'number' ? school.elaProficient : null, countyAvg.elaProficient) : null
   const mathDelta = countyAvg ? formatDelta(typeof school.mathProficient === 'number' ? school.mathProficient : null, countyAvg.mathProficient) : null
@@ -89,5 +89,7 @@ export default React.memo(function SchoolMarker({ school, isSelected, onSelect, 
   prev.school.id === next.school.id
   && prev.isSelected === next.isSelected
   && prev.onSelect === next.onSelect
-  && prev.avgScope === next.avgScope
+  // Only the two fields the delta scope reads — filters is a fresh object every render.
+  && prev.filters.county === next.filters.county
+  && !!prev.filters.proximity === !!next.filters.proximity
 )

--- a/src/components/panel/FilterResults.tsx
+++ b/src/components/panel/FilterResults.tsx
@@ -9,10 +9,12 @@ import { findSchoolZonesForPoint, type ZoneLookupResult } from '@/utils/findScho
 import { haversineDistanceMiles } from '@/utils/haversine'
 import SchoolCard, { METRIC_GRID_CLASS } from './SchoolCard'
 import { useCountyAverages } from '@/hooks/useCountyAverages'
-import { countyLevelKey, STATE_SCOPE } from '@/utils/countyAverages'
+import { countyLevelKey, deltaScope, schoolDeltaAverage, STATE_SCOPE, type CountyLevelAverages } from '@/utils/countyAverages'
 import type { SchoolLevel } from '@/types/school'
 
 type SortKey = 'name' | 'starRating' | 'indexScore' | 'distanceMiles'
+
+const LEVELS: SchoolLevel[] = ['Elementary', 'Middle', 'High']
 
 interface SortOption { label: string; value: SortKey }
 
@@ -58,6 +60,56 @@ function scopeLabel(scope: string): string {
   return scope === 'Carson City' ? scope : `${scope} County`
 }
 
+// The banner is grouped by the same scope the cards' deltas are measured against, so the
+// two always agree. In a proximity search that is each school's own county — normally one
+// section, but two when the results straddle a county line. Levels track the schools shown.
+function AveragesBanner({ filters, schools, countyAvgMap }: {
+  filters: FilterState
+  schools: School[]
+  countyAvgMap: Map<string, CountyLevelAverages> | null
+}) {
+  const scopes = [...new Set(schools.map(s => deltaScope(s, filters)).filter((s): s is string => s != null))].sort()
+  const sections = scopes
+    .map(scope => ({
+      scope,
+      // Drive the order from LEVELS, not the school order, which is whatever the sort produced.
+      rows: LEVELS
+        .filter(l => schools.some(s => s.level === l && deltaScope(s, filters) === scope))
+        .map(l => countyAvgMap?.get(countyLevelKey(scope, l)))
+        .filter((a): a is CountyLevelAverages => a != null),
+    }))
+    .filter(section => section.rows.length > 0)
+
+  if (sections.length === 0) return null
+
+  return (
+    <div className="mb-3 rounded-lg border border-blue-100 bg-blue-50 p-3 text-blue-700 flex flex-col gap-3">
+      {sections.map(({ scope, rows }) => (
+        <div key={scope}>
+          <div className="font-semibold text-blue-800 text-sm leading-tight mb-1">{scopeLabel(scope)} averages</div>
+          <div className="flex flex-col gap-2">
+            {rows.map(a => (
+              <div key={a.level} className="flex gap-4 items-start">
+                <div className="flex-1 min-w-0 text-xs font-semibold text-blue-800">{a.level}</div>
+                <div className={METRIC_GRID_CLASS}>
+                  <div>
+                    <div className="text-blue-400">ELA Proficient</div>
+                    <div className="font-medium">{a.elaProficient != null ? `${a.elaProficient.toFixed(1)}%` : '—'}</div>
+                  </div>
+                  <div>
+                    <div className="text-blue-400">Math Proficient</div>
+                    <div className="font-medium">{a.mathProficient != null ? `${a.mathProficient.toFixed(1)}%` : '—'}</div>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
 function sortSchools<T extends School>(schools: T[], sortKey: SortKey, sortAsc: boolean): T[] {
   return [...schools].sort((a, b) => {
     const av = (a as Record<string, unknown>)[sortKey]
@@ -83,7 +135,6 @@ function ProximityPanel({ filters, onSelectSchool, onZoneResult }: FilterResults
 
   const { schools: allSchools } = useSchools(DEFAULT_FILTERS)
   const countyAvgMap = useCountyAverages()
-  const avgScope = filters.county ?? STATE_SCOPE
   const { geojson, loading: zonesLoading } = useSchoolZones(true)
   const [zoneResult, setZoneResult] = useState<ZoneLookupResult | null>(null)
   const onZoneResultRef = useRef(onZoneResult)
@@ -120,6 +171,7 @@ function ProximityPanel({ filters, onSelectSchool, onZoneResult }: FilterResults
     const zonedSchools = [zoneResult.Elementary, zoneResult.Middle, zoneResult.High].filter(Boolean) as School[]
     return (
       <div className="bg-white px-4 py-3 h-full">
+        <AveragesBanner filters={filters} schools={zonedSchools} countyAvgMap={countyAvgMap} />
         <p className="text-xs text-gray-500 font-medium mb-2">
           {zonedSchools.length} {zonedSchools.length === 1 ? 'school' : 'schools'} matched
         </p>
@@ -129,7 +181,7 @@ function ProximityPanel({ filters, onSelectSchool, onZoneResult }: FilterResults
               key={s.id}
               school={s}
               distanceMiles={s.lat != null && s.lng != null ? haversineDistanceMiles(proximity.lat, proximity.lng, s.lat, s.lng) : null}
-              countyAvg={countyAvgMap ? countyAvgMap.get(countyLevelKey(avgScope, s.level)) ?? null : null}
+              countyAvg={schoolDeltaAverage(countyAvgMap, s, filters)}
               onSelect={onSelectSchool}
             />
           ))}
@@ -142,6 +194,7 @@ function ProximityPanel({ filters, onSelectSchool, onZoneResult }: FilterResults
 
   return (
     <div className="bg-white px-4 py-3 h-full">
+      <AveragesBanner filters={filters} schools={nearbySchools} countyAvgMap={countyAvgMap} />
       <div className="flex items-center justify-between mb-2">
         <p className="text-xs text-gray-500 font-medium">
 {nearbySchools.length === 0 ? 'No' : nearbySchools.length} {nearbySchools.length === 1 ? 'school' : 'schools'} matched
@@ -150,7 +203,7 @@ function ProximityPanel({ filters, onSelectSchool, onZoneResult }: FilterResults
       </div>
       <div className="flex flex-col gap-3">
         {sortedNearby.map((school) => (
-          <SchoolCard key={school.id} school={school} distanceMiles={school.distanceMiles} countyAvg={countyAvgMap ? countyAvgMap.get(countyLevelKey(avgScope, school.level)) ?? null : null} onSelect={onSelectSchool} />
+          <SchoolCard key={school.id} school={school} distanceMiles={school.distanceMiles} countyAvg={schoolDeltaAverage(countyAvgMap, school, filters)} onSelect={onSelectSchool} />
         ))}
       </div>
     </div>
@@ -169,18 +222,6 @@ function NonProximityPanel({ filters, onSelectSchool }: Pick<FilterResultsProps,
     [schools, sortKey, sortAsc]
   )
 
-  const LEVELS: SchoolLevel[] = ['Elementary', 'Middle', 'High']
-  // Drive the order from LEVELS, not filters.schoolLevels — the latter is ordered by
-  // the sequence the user clicked the filters in.
-  const activeLevels = LEVELS.filter(
-    l => filters.schoolLevels.length === 0 || filters.schoolLevels.includes(l)
-  )
-  // With no county selected there is no county to average, so fall back to statewide.
-  const avgScope = filters.county ?? STATE_SCOPE
-  const countyLevelAvgs = countyAvgMap
-    ? activeLevels.map(l => countyAvgMap.get(countyLevelKey(avgScope, l))).filter(Boolean)
-    : []
-
   if (loading) return (
     <div className="bg-white px-4 py-2 text-xs text-gray-500">
       Loading…
@@ -189,28 +230,7 @@ function NonProximityPanel({ filters, onSelectSchool }: Pick<FilterResultsProps,
 
   return (
     <div className="bg-white px-4 py-3 h-full">
-      {countyLevelAvgs.length > 0 && (
-        <div className="mb-3 rounded-lg border border-blue-100 bg-blue-50 p-3 text-blue-700">
-          <div className="font-semibold text-blue-800 text-sm leading-tight mb-1">{scopeLabel(avgScope)} averages</div>
-          <div className="flex flex-col gap-2">
-            {countyLevelAvgs.map(a => a && (
-              <div key={a.level} className="flex gap-4 items-start">
-                <div className="flex-1 min-w-0 text-xs font-semibold text-blue-800">{a.level}</div>
-                <div className={METRIC_GRID_CLASS}>
-                  <div>
-                    <div className="text-blue-400">ELA Proficient</div>
-                    <div className="font-medium">{a.elaProficient != null ? `${a.elaProficient.toFixed(1)}%` : '—'}</div>
-                  </div>
-                  <div>
-                    <div className="text-blue-400">Math Proficient</div>
-                    <div className="font-medium">{a.mathProficient != null ? `${a.mathProficient.toFixed(1)}%` : '—'}</div>
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
+      <AveragesBanner filters={filters} schools={schools} countyAvgMap={countyAvgMap} />
       <div className="flex items-center justify-between mb-2">
         <p className="text-xs text-gray-500 font-medium">
 {schools.length === 0 ? 'No' : schools.length} {schools.length === 1 ? 'school' : 'schools'} matched
@@ -222,7 +242,7 @@ function NonProximityPanel({ filters, onSelectSchool }: Pick<FilterResultsProps,
           <SchoolCard
             key={school.id}
             school={school}
-            countyAvg={countyAvgMap ? countyAvgMap.get(countyLevelKey(avgScope, school.level)) ?? null : null}
+            countyAvg={schoolDeltaAverage(countyAvgMap, school, filters)}
             onSelect={onSelectSchool}
           />
         ))}

--- a/src/utils/countyAverages.ts
+++ b/src/utils/countyAverages.ts
@@ -1,4 +1,4 @@
-import type { SchoolLevel } from '@/types/school'
+import type { FilterState, School, SchoolLevel } from '@/types/school'
 
 // Official county averages published by NDE (Nevada Report Card), not computed
 // from our own school list -- averaging school-level averages is statistically
@@ -17,6 +17,24 @@ export const STATE_SCOPE = 'State'
 
 export function countyLevelKey(county: string, level: SchoolLevel): string {
   return `${county}:${level}`
+}
+
+// Which average a school's delta is measured against. A proximity search is anchored to
+// a place, not a scope, and its results can straddle a county line -- so each school is
+// compared to its own county. Otherwise the list is exactly the county filter's scope
+// (statewide when there is no filter), and that is what the delta means.
+export function deltaScope(school: School, filters: FilterState): string | null {
+  return filters.proximity ? school.county : filters.county ?? STATE_SCOPE
+}
+
+export function schoolDeltaAverage(
+  averages: Map<string, CountyLevelAverages> | null,
+  school: School,
+  filters: FilterState
+): CountyLevelAverages | null {
+  const scope = deltaScope(school, filters)
+  if (!averages || scope == null) return null
+  return averages.get(countyLevelKey(scope, school.level)) ?? null
 }
 
 export function formatDelta(school: number | null, countyAvg: number | null): string | null {


### PR DESCRIPTION
## Summary
- Proficiency deltas on school cards and map popups now compare against the school's **own county** during a proximity (address/zone) search, instead of the statewide figure. A proximity search is anchored to a place rather than a scope, and its results can straddle a county line. Outside proximity mode the behavior is unchanged: the county filter's scope, or statewide when there is no filter. The rule lives in `schoolDeltaAverage` (`src/utils/countyAverages.ts`), shared by the panel and the map so a given school always shows the same delta in both.
- The county/state averages banner now renders in proximity mode too — it previously lived only in `NonProximityPanel`, so searching an address silently dropped the benchmark. It groups by the same scope the deltas use (one section per county present in the results), and its rows track the levels of the schools shown beneath it.
- `SchoolMarker` / `CountyClusterMarkers` take `filters` in place of the old `avgScope` string; the marker's memo comparator was narrowed to the two fields the scope actually reads, so markers don't re-render on unrelated filter changes.

## Test plan
- [ ] No proximity, no county filter — banner reads "Nevada statewide averages"; card deltas are vs. statewide (unchanged).
- [ ] County filter selected — banner reads "<County> County averages" ("Carson City averages", no suffix, for Carson City); deltas vs. that county (unchanged).
- [ ] Zone mode — search an address, leave the pill on `Zone`. Banner appears above the zoned cards, scoped to the school's county; one row per level the zone lookup returned.
- [ ] Radius mode (3/5/10 mi) — banner stays visible, rows track the levels among the matches; a radius with zero matches shows no banner (not an empty blue box).
- [ ] Address near a county line — results spanning two counties render a banner section per county, and each card's delta matches the section for its county.
- [ ] Map popups agree with the panel card for the same school in every mode above.
- [ ] `npm run lint` and `npm run build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)