### PR TITLE
Fix missing distance in table view during zone mode

### DIFF
--- a/src/hooks/useSchools.ts
+++ b/src/hooks/useSchools.ts
@@ -71,6 +71,14 @@ export function useSchools(filters: FilterState) {
         if (distanceMiles > filters.proximity.radiusMiles) continue
       } else if (filters.proximity && filters.proximity.radiusMiles === 0) {
         if (filters.zonedSchoolIds.length === 0 || !filters.zonedSchoolIds.includes(school.id)) continue
+        if (school.lat !== null && school.lng !== null) {
+          distanceMiles = haversineDistanceMiles(
+            filters.proximity.lat,
+            filters.proximity.lng,
+            school.lat,
+            school.lng
+          )
+        }
       }
 
       result.push({ ...school, distanceMiles })


### PR DESCRIPTION
## Summary
- Zone mode (`radiusMiles === 0`) filtered schools by `zonedSchoolIds` but never computed `distanceMiles`, so the table's Distance column showed `—` for every zoned school
- Now computes `distanceMiles` via the existing haversine helper whenever the school has coordinates, matching the radius-search code path

## Test plan
- [ ] Run a proximity search with a radius (e.g. "5 mi") and confirm the Distance column still populates and sorts correctly
- [ ] Switch to a zoned school search (radius = 0) and confirm the Distance column now shows values instead of `—`
- [ ] Confirm sorting by Distance works in zone mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)