### PR TITLE
Add school comparison panel + MGP growth metrics

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -73,14 +73,22 @@ export default function AboutPage() {
         <section className="mb-8">
           <h3 className="text-lg font-semibold text-gray-900 mb-2">Growth Metrics</h3>
           <p className="text-gray-700 leading-relaxed">
-            ELA Growth and Math Growth come from the Nevada Growth Model, which measures
-            year-over-year student progress by comparing each student to academic peers statewide —
-            students who had similar prior test scores.
+            Growth - AGP and Growth - MGP are both measures of student progress over time, rather
+            than a snapshot of proficiency — but they come from different sources and are
+            calculated differently.
           </p>
           <p className="text-gray-700 leading-relaxed mt-3">
-            Each figure is the percentage of students at the school who met their individual growth
-            target for the year — the amount of progress needed to reach or stay proficient. A
-            higher percentage means more students are on track.
+            <strong>Growth - AGP</strong> is the percentage of students at the school who met their
+            individual growth target for the year — the amount of progress needed to reach or stay
+            proficient. A higher percentage means more students are on track.
+          </p>
+          <p className="text-gray-700 leading-relaxed mt-3">
+            <strong>Growth - MGP</strong> (Median Growth Percentile) comes from the Nevada Growth
+            Model, which compares each student&apos;s year-over-year progress to academic peers
+            statewide — students who had similar prior test scores. A school&apos;s MGP is the
+            median of its students&apos; individual growth percentiles; 50 represents typical
+            growth for the state. MGP is only reported for grades 3–8, so it does not appear for
+            high schools.
           </p>
         </section>
 
@@ -101,7 +109,7 @@ export default function AboutPage() {
             https://nevadareportcard.nv.gov/di/
           </a>
           <p className="text-gray-700 leading-relaxed mt-3">
-            Growth percentiles come from the Nevada Growth Model:
+            Growth - MGP percentiles come from the Nevada Growth Model:
           </p>
           <a
             href="https://ngma.bighorn.doe.nv.gov/nvgrowthmodel"

--- a/src/app/schools/page.tsx
+++ b/src/app/schools/page.tsx
@@ -16,7 +16,11 @@ import { useSchools } from '@/hooks/useSchools'
 import MapView from '@/components/map/MapView'
 import TableView from '@/components/table/TableView'
 import FilterResults from '@/components/panel/FilterResults'
-import { parseFilters, serializeFilters } from '@/utils/filterParams'
+import SchoolComparison from '@/components/panel/SchoolComparison'
+import { hasActiveFilters, parseFilters, serializeFilters } from '@/utils/filterParams'
+
+// Tailwind's xl breakpoint — the width at which the results panel appears beside the map.
+const DESKTOP_QUERY = '(min-width: 1280px)'
 
 function HomeContent() {
   const router = useRouter()
@@ -27,6 +31,13 @@ function HomeContent() {
   const [selectedSchool, setSelectedSchool] = useState<School | null>(null)
   const [addressError, setAddressError] = useState<string | null>(null)
   const isPopState = useRef(false)
+  const mobileListRef = useRef<HTMLDivElement>(null)
+
+  // The chart takes the banner's place at the top of the list, so a card tapped further down
+  // would swap in a chart the user can't see. Bring it back into view.
+  useEffect(() => {
+    if (selectedSchool) mobileListRef.current?.scrollTo({ top: 0, behavior: 'smooth' })
+  }, [selectedSchool])
 
   useEffect(() => {
     function handlePopState() {
@@ -52,16 +63,14 @@ function HomeContent() {
 
   const handleSelectSchool = useCallback((school: School) => {
     setSelectedSchool(school)
-    setView('map')
+    // Below xl there is no side panel next to the map, so the comparison chart lives in the
+    // list itself — jumping to the map would be jumping away from the thing just selected.
+    if (window.matchMedia(DESKTOP_QUERY).matches) setView('map')
   }, [])
 
-  const hasActive =
-    filters.search !== '' ||
-    filters.schoolTypes.length > 0 ||
-    filters.schoolLevels.length > 0 ||
-    filters.starRatings.length > 0 ||
-    filters.county !== null ||
-    filters.proximity !== null
+  const hasActive = hasActiveFilters(filters)
+
+  const clearSelection = useCallback(() => setSelectedSchool(null), [])
 
   const { schools: filteredSchools } = useSchools(filters)
 
@@ -135,8 +144,10 @@ function HomeContent() {
             >
               Map
             </button>
+            {/* The selection survives the trip, so coming back to the map lands on the same
+                school with its popup open. */}
             <button
-              onClick={() => { setView('table'); setSelectedSchool(null) }}
+              onClick={() => setView('table')}
               className={`px-2.5 py-0.5 text-xs font-bold border-l border-gray-300 transition-colors ${view === 'table' ? 'bg-blue-600 text-white' : 'bg-white text-gray-600 hover:border-gray-400'}`}
             >
               <span className="xl:hidden">List</span>
@@ -199,12 +210,14 @@ function HomeContent() {
         </div>
       </div>
 
-      {/* Mobile filter drawer — always mounted, manages its own open/close */}
+      {/* Mobile filter drawer — always mounted, manages its own open/close.
+          Unlike the view toggle, "View Schools" drops the selection: the chart covers the
+          list, and this button is a request for the list. */}
       <FilterDrawer
         filters={filters}
         onChange={setFilters}
         onClear={clearFilters}
-        onViewSchools={() => { setView('table'); setSelectedSchool(null) }}
+        onViewSchools={() => { setView('table'); clearSelection() }}
         filterCount={filterCount}
         schoolCount={filteredSchools.length}
       />
@@ -212,14 +225,24 @@ function HomeContent() {
       {/* Main content */}
       <main className="flex-1 overflow-hidden">
         <div className={view === 'map' ? 'flex xl:flex-row h-full' : 'hidden'}>
-          {hasActive && (
+          {(hasActive || selectedSchool) && (
             <div className="hidden xl:block shrink-0 xl:w-1/3 xl:border-r border-gray-200 overflow-y-auto">
-              <FilterResults
-                filters={filters}
-                onSelectSchool={handleSelectSchool}
-                onZoneResult={(ids) => setFilters((f) => ({ ...f, zonedSchoolIds: ids }))}
-                onZoneFallback={handleZoneFallback}
-              />
+              {hasActive ? (
+                <FilterResults
+                  filters={filters}
+                  selectedSchool={selectedSchool}
+                  onSelectSchool={handleSelectSchool}
+                  onClearSelection={clearSelection}
+                  onZoneResult={(ids) => setFilters((f) => ({ ...f, zonedSchoolIds: ids }))}
+                  onZoneFallback={handleZoneFallback}
+                />
+              ) : selectedSchool && (
+                // Marker clicked on an unfiltered map: the panel opens purely to carry the
+                // chart. Rendering the results list here would list every school in Nevada.
+                <div className="bg-white px-4 py-3 h-full">
+                  <SchoolComparison school={selectedSchool} onClear={clearSelection} />
+                </div>
+              )}
             </div>
           )}
           <div className="flex-1 min-h-0">
@@ -232,10 +255,12 @@ function HomeContent() {
             <TableView filters={filters} onSelectSchool={handleSelectSchool} />
           </div>
           {/* Mobile: scrollable card list */}
-          <div className="xl:hidden h-full overflow-y-auto">
+          <div ref={mobileListRef} className="xl:hidden h-full overflow-y-auto">
             <FilterResults
               filters={filters}
+              selectedSchool={selectedSchool}
               onSelectSchool={handleSelectSchool}
+              onClearSelection={clearSelection}
               onZoneResult={(ids) => setFilters((f) => ({ ...f, zonedSchoolIds: ids }))}
               onZoneFallback={handleZoneFallback}
             />

--- a/src/components/map/CountyClusterMarkers.tsx
+++ b/src/components/map/CountyClusterMarkers.tsx
@@ -4,7 +4,7 @@ import { useMemo, useState, useCallback } from 'react'
 import { useMapEvents } from 'react-leaflet'
 import SchoolMarker from './SchoolMarker'
 import CountyPolygons from './CountyPolygons'
-import type { FilterState, School, SchoolWithDistance } from '@/types/school'
+import type { School, SchoolWithDistance } from '@/types/school'
 
 const CLUSTER_ZOOM_THRESHOLD = 9
 
@@ -14,8 +14,8 @@ interface CountyClusterMarkersProps {
   onSelectSchool?: (school: School) => void
   forceIndividual?: boolean
   onCountyFilter?: (county: string) => void
-  // Picks the scope the popup deltas compare against — see schoolDeltaAverage.
-  filters: FilterState
+  // The selected school's popup is only open while the map is the view on screen — see SchoolMarker.
+  isMapVisible?: boolean
 }
 
 export default function CountyClusterMarkers({
@@ -24,7 +24,7 @@ export default function CountyClusterMarkers({
   onSelectSchool,
   forceIndividual,
   onCountyFilter,
-  filters,
+  isMapVisible = true,
 }: CountyClusterMarkersProps) {
   const map = useMapEvents({
     zoomend: () => setZoom(map.getZoom()),
@@ -63,7 +63,7 @@ export default function CountyClusterMarkers({
             school={school}
             isSelected={selectedSchool?.id === school.id}
             onSelect={onSelectSchool}
-            filters={filters}
+            isMapVisible={isMapVisible}
           />
         ))}
       </>

--- a/src/components/map/MapInner.tsx
+++ b/src/components/map/MapInner.tsx
@@ -137,7 +137,7 @@ export default function MapInner({ filters, selectedSchool, isVisible, onSelectS
         onSelectSchool={onSelectSchool}
         forceIndividual={!!filters.county || !!filters.proximity}
         onCountyFilter={onCountyFilter}
-        filters={filters}
+        isMapVisible={isVisible ?? true}
       />
     </MapContainer>
   )

--- a/src/components/map/SchoolMarker.tsx
+++ b/src/components/map/SchoolMarker.tsx
@@ -4,44 +4,53 @@ import React, { useEffect, useRef } from 'react'
 import { Marker, Popup } from 'react-leaflet'
 import type L from 'leaflet'
 import { createMarkerIcon, getMarkerColor } from '@/utils/markerColors'
-import type { FilterState, SchoolWithDistance } from '@/types/school'
-import { useCountyAverages } from '@/hooks/useCountyAverages'
-import { formatDelta, deltaColor, schoolDeltaAverage } from '@/utils/countyAverages'
+import type { SchoolWithDistance } from '@/types/school'
 
 interface SchoolMarkerProps {
   school: SchoolWithDistance
   isSelected?: boolean
   onSelect?: (school: SchoolWithDistance) => void
-  // Picks the scope the deltas compare against — see schoolDeltaAverage.
-  filters: FilterState
+  isMapVisible?: boolean
 }
 
-export default React.memo(function SchoolMarker({ school, isSelected, onSelect, filters }: SchoolMarkerProps) {
+export default React.memo(function SchoolMarker({ school, isSelected, onSelect, isMapVisible = true }: SchoolMarkerProps) {
   const icon = createMarkerIcon(school.starRating)
   const markerRef = useRef<L.Marker>(null)
-  const countyAvgMap = useCountyAverages()
-  const countyAvg = schoolDeltaAverage(countyAvgMap, school, filters)
-  // NDE only publishes county proficiency, so those are the only deltas we can show.
-  const elaDelta = countyAvg ? formatDelta(typeof school.elaProficient === 'number' ? school.elaProficient : null, countyAvg.elaProficient) : null
-  const mathDelta = countyAvg ? formatDelta(typeof school.mathProficient === 'number' ? school.mathProficient : null, countyAvg.mathProficient) : null
+
+  // The popup is open exactly while its school is selected and the map is the view on screen.
+  // Driving it from both means it closes when the user leaves for the list and comes back on
+  // return — the map is only CSS-hidden, so a popup left open would otherwise still be there.
+  const showPopup = isSelected && isMapVisible
 
   useEffect(() => {
-    if (isSelected && markerRef.current) {
+    if (!markerRef.current) return
+    if (showPopup) {
       markerRef.current.openPopup()
+    } else {
+      markerRef.current.closePopup()
     }
-  }, [isSelected])
+  }, [showPopup])
 
   if (school.lat === null || school.lng === null) return null
 
   return (
     <Marker ref={markerRef} position={[school.lat, school.lng]} icon={icon} eventHandlers={{ click: () => onSelect?.(school) }}>
       <Popup>
-        <div className="min-w-[220px]">
-          <div className="flex items-baseline justify-between gap-2">
+        <div className="min-w-[280px]">
+          <div className="flex items-center gap-2 mb-1">
             <p className="font-semibold text-sm truncate min-w-0">{school.name}</p>
+            <span className="shrink-0 text-xs font-medium" style={{ color: getMarkerColor(school.starRating) }}>
+              {school.starRating !== null ? '★'.repeat(school.starRating) : 'NR'}
+            </span>
             {school.distanceMiles != null && (
               <span className="text-xs font-medium text-gray-500 shrink-0">{school.distanceMiles.toFixed(1)} mi</span>
             )}
+            <span
+              className="ml-auto shrink-0 text-sm font-bold"
+              style={{ color: getMarkerColor(school.starRating) }}
+            >
+              {Math.trunc(school.indexScore)}
+            </span>
           </div>
           <p className="text-xs text-gray-500 mb-1">{school.level} · {school.type}</p>
           {school.address && school.city && (
@@ -55,30 +64,30 @@ export default React.memo(function SchoolMarker({ school, isSelected, onSelect, 
               <span className="block">{school.city}, NV{school.zip ? ` ${school.zip}` : ''}</span>
             </a>
           )}
-          <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs mt-0">
-            <div>
-              <div className="text-gray-400">Stars</div>
-              <div className="font-medium" style={{ color: getMarkerColor(school.starRating) }}>{school.starRating !== null ? '★'.repeat(school.starRating) : 'NR'}</div>
-            </div>
-            <div>
-              <div className="text-gray-400">Score</div>
-              <div className="font-medium">{school.indexScore}</div>
-            </div>
+          <div className="grid grid-cols-2 gap-x-3 gap-y-1 text-xs mt-0">
             <div>
               <div className="text-gray-400">ELA Proficient</div>
-              <div className="font-medium">{school.elaProficient != null ? `${school.elaProficient}%` : '—'}{elaDelta && <span className={`ml-1 font-normal ${deltaColor(elaDelta)}`}>({elaDelta}%)</span>}</div>
+              <div className="font-medium">{school.elaProficient != null ? `${school.elaProficient}%` : '—'}</div>
             </div>
             <div>
               <div className="text-gray-400">Math Proficient</div>
-              <div className="font-medium">{school.mathProficient != null ? `${school.mathProficient}%` : '—'}{mathDelta && <span className={`ml-1 font-normal ${deltaColor(mathDelta)}`}>({mathDelta}%)</span>}</div>
+              <div className="font-medium">{school.mathProficient != null ? `${school.mathProficient}%` : '—'}</div>
             </div>
             <div>
-              <div className="text-gray-400">ELA Growth</div>
+              <div className="text-gray-400">ELA Growth - AGP</div>
               <div className="font-medium">{school.elaGrowth != null ? `${school.elaGrowth}%` : '—'}</div>
             </div>
             <div>
-              <div className="text-gray-400">Math Growth</div>
+              <div className="text-gray-400">Math Growth - AGP</div>
               <div className="font-medium">{school.mathGrowth != null ? `${school.mathGrowth}%` : '—'}</div>
+            </div>
+            <div>
+              <div className="text-gray-400">ELA Growth - MGP</div>
+              <div className="font-medium">{school.elaMgp != null ? Math.round(school.elaMgp) : '—'}</div>
+            </div>
+            <div>
+              <div className="text-gray-400">Math Growth - MGP</div>
+              <div className="font-medium">{school.mathMgp != null ? Math.round(school.mathMgp) : '—'}</div>
             </div>
           </div>
         </div>
@@ -89,7 +98,5 @@ export default React.memo(function SchoolMarker({ school, isSelected, onSelect, 
   prev.school.id === next.school.id
   && prev.isSelected === next.isSelected
   && prev.onSelect === next.onSelect
-  // Only the two fields the delta scope reads — filters is a fresh object every render.
-  && prev.filters.county === next.filters.county
-  && !!prev.filters.proximity === !!next.filters.proximity
+  && prev.isMapVisible === next.isMapVisible
 )

--- a/src/components/panel/FilterResults.tsx
+++ b/src/components/panel/FilterResults.tsx
@@ -7,14 +7,10 @@ import { useSchools } from '@/hooks/useSchools'
 import { useSchoolZones } from '@/hooks/useSchoolZones'
 import { findSchoolZonesForPoint, type ZoneLookupResult } from '@/utils/findSchoolZones'
 import { haversineDistanceMiles } from '@/utils/haversine'
-import SchoolCard, { METRIC_GRID_CLASS } from './SchoolCard'
-import { useCountyAverages } from '@/hooks/useCountyAverages'
-import { countyLevelKey, deltaScope, schoolDeltaAverage, STATE_SCOPE, type CountyLevelAverages } from '@/utils/countyAverages'
-import type { SchoolLevel } from '@/types/school'
+import SchoolCard from './SchoolCard'
+import SchoolComparison from './SchoolComparison'
 
 type SortKey = 'name' | 'starRating' | 'indexScore' | 'distanceMiles'
-
-const LEVELS: SchoolLevel[] = ['Elementary', 'Middle', 'High']
 
 interface SortOption { label: string; value: SortKey }
 
@@ -54,62 +50,6 @@ function SortBar({ sortKey, sortAsc, options, onSortKeyChange, onSortAscChange }
   )
 }
 
-// Carson City is an independent city, not a county — "Carson City County" would be wrong.
-function scopeLabel(scope: string): string {
-  if (scope === STATE_SCOPE) return 'Nevada statewide'
-  return scope === 'Carson City' ? scope : `${scope} County`
-}
-
-// The banner is grouped by the same scope the cards' deltas are measured against, so the
-// two always agree. In a proximity search that is each school's own county — normally one
-// section, but two when the results straddle a county line. Levels track the schools shown.
-function AveragesBanner({ filters, schools, countyAvgMap }: {
-  filters: FilterState
-  schools: School[]
-  countyAvgMap: Map<string, CountyLevelAverages> | null
-}) {
-  const scopes = [...new Set(schools.map(s => deltaScope(s, filters)).filter((s): s is string => s != null))].sort()
-  const sections = scopes
-    .map(scope => ({
-      scope,
-      // Drive the order from LEVELS, not the school order, which is whatever the sort produced.
-      rows: LEVELS
-        .filter(l => schools.some(s => s.level === l && deltaScope(s, filters) === scope))
-        .map(l => countyAvgMap?.get(countyLevelKey(scope, l)))
-        .filter((a): a is CountyLevelAverages => a != null),
-    }))
-    .filter(section => section.rows.length > 0)
-
-  if (sections.length === 0) return null
-
-  return (
-    <div className="mb-3 rounded-lg border border-blue-100 bg-blue-50 p-3 text-blue-700 flex flex-col gap-3">
-      {sections.map(({ scope, rows }) => (
-        <div key={scope}>
-          <div className="font-semibold text-blue-800 text-sm leading-tight mb-1">{scopeLabel(scope)} averages</div>
-          <div className="flex flex-col gap-2">
-            {rows.map(a => (
-              <div key={a.level} className="flex gap-4 items-start">
-                <div className="flex-1 min-w-0 text-xs font-semibold text-blue-800">{a.level}</div>
-                <div className={METRIC_GRID_CLASS}>
-                  <div>
-                    <div className="text-blue-400">ELA Proficient</div>
-                    <div className="font-medium">{a.elaProficient != null ? `${a.elaProficient.toFixed(1)}%` : '—'}</div>
-                  </div>
-                  <div>
-                    <div className="text-blue-400">Math Proficient</div>
-                    <div className="font-medium">{a.mathProficient != null ? `${a.mathProficient.toFixed(1)}%` : '—'}</div>
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      ))}
-    </div>
-  )
-}
-
 function sortSchools<T extends School>(schools: T[], sortKey: SortKey, sortAsc: boolean): T[] {
   return [...schools].sort((a, b) => {
     const av = (a as Record<string, unknown>)[sortKey]
@@ -125,17 +65,18 @@ function sortSchools<T extends School>(schools: T[], sortKey: SortKey, sortAsc: 
 
 interface FilterResultsProps {
   filters: FilterState
+  selectedSchool: School | null
   onSelectSchool: (school: School) => void
+  onClearSelection: () => void
   onZoneResult: (ids: string[]) => void
   onZoneFallback: () => void
 }
 
-function ProximityPanel({ filters, onSelectSchool, onZoneResult, onZoneFallback }: FilterResultsProps) {
+function ProximityPanel({ filters, selectedSchool, onSelectSchool, onClearSelection, onZoneResult, onZoneFallback }: FilterResultsProps) {
   const proximity = filters.proximity!
   const isZone = proximity.radiusMiles === 0
 
   const { schools: allSchools } = useSchools(DEFAULT_FILTERS)
-  const countyAvgMap = useCountyAverages()
   const { geojson, loading: zonesLoading } = useSchoolZones(true)
   const [zoneResult, setZoneResult] = useState<ZoneLookupResult | null>(null)
   const onZoneResultRef = useRef(onZoneResult)
@@ -179,21 +120,25 @@ function ProximityPanel({ filters, onSelectSchool, onZoneResult, onZoneFallback 
     const zonedSchools = [zoneResult.Elementary, zoneResult.Middle, zoneResult.High].filter(Boolean) as School[]
     return (
       <div className="bg-white px-4 py-3 h-full">
-        <AveragesBanner filters={filters} schools={zonedSchools} countyAvgMap={countyAvgMap} />
-        <p className="text-xs text-gray-500 font-medium mb-2">
-          {zonedSchools.length} {zonedSchools.length === 1 ? 'school' : 'schools'} matched
-        </p>
-        <div className="flex flex-col gap-3">
-          {zonedSchools.map((s) => (
-            <SchoolCard
-              key={s.id}
-              school={s}
-              distanceMiles={s.lat != null && s.lng != null ? haversineDistanceMiles(proximity.lat, proximity.lng, s.lat, s.lng) : null}
-              countyAvg={schoolDeltaAverage(countyAvgMap, s, filters)}
-              onSelect={onSelectSchool}
-            />
-          ))}
-        </div>
+        {selectedSchool ? (
+          <SchoolComparison school={selectedSchool} onClear={onClearSelection} />
+        ) : (
+          <>
+            <p className="text-xs text-gray-500 font-medium mb-2">
+              {zonedSchools.length} {zonedSchools.length === 1 ? 'school' : 'schools'} matched
+            </p>
+            <div className="flex flex-col gap-3">
+              {zonedSchools.map((s) => (
+                <SchoolCard
+                  key={s.id}
+                  school={s}
+                  distanceMiles={s.lat != null && s.lng != null ? haversineDistanceMiles(proximity.lat, proximity.lng, s.lat, s.lng) : null}
+                  onSelect={onSelectSchool}
+                />
+              ))}
+            </div>
+          </>
+        )}
       </div>
     )
   }
@@ -202,25 +147,29 @@ function ProximityPanel({ filters, onSelectSchool, onZoneResult, onZoneFallback 
 
   return (
     <div className="bg-white px-4 py-3 h-full">
-      <AveragesBanner filters={filters} schools={nearbySchools} countyAvgMap={countyAvgMap} />
-      <div className="flex items-center justify-between mb-2">
-        <p className="text-xs text-gray-500 font-medium">
-{nearbySchools.length === 0 ? 'No' : nearbySchools.length} {nearbySchools.length === 1 ? 'school' : 'schools'} matched
-        </p>
-        <SortBar sortKey={sortKey} sortAsc={sortAsc} options={radiusOptions} onSortKeyChange={setSortKey} onSortAscChange={setSortAsc} />
-      </div>
-      <div className="flex flex-col gap-3">
-        {sortedNearby.map((school) => (
-          <SchoolCard key={school.id} school={school} distanceMiles={school.distanceMiles} countyAvg={schoolDeltaAverage(countyAvgMap, school, filters)} onSelect={onSelectSchool} />
-        ))}
-      </div>
+      {selectedSchool ? (
+        <SchoolComparison school={selectedSchool} onClear={onClearSelection} />
+      ) : (
+        <>
+          <div className="flex items-center justify-between mb-2">
+            <p className="text-xs text-gray-500 font-medium">
+              {nearbySchools.length === 0 ? 'No' : nearbySchools.length} {nearbySchools.length === 1 ? 'school' : 'schools'} matched
+            </p>
+            <SortBar sortKey={sortKey} sortAsc={sortAsc} options={radiusOptions} onSortKeyChange={setSortKey} onSortAscChange={setSortAsc} />
+          </div>
+          <div className="flex flex-col gap-3">
+            {sortedNearby.map((school) => (
+              <SchoolCard key={school.id} school={school} distanceMiles={school.distanceMiles} onSelect={onSelectSchool} />
+            ))}
+          </div>
+        </>
+      )}
     </div>
   )
 }
 
-function NonProximityPanel({ filters, onSelectSchool }: Pick<FilterResultsProps, 'filters' | 'onSelectSchool'>) {
+function NonProximityPanel({ filters, selectedSchool, onSelectSchool, onClearSelection }: Pick<FilterResultsProps, 'filters' | 'selectedSchool' | 'onSelectSchool' | 'onClearSelection'>) {
   const { schools, loading } = useSchools(filters)
-  const countyAvgMap = useCountyAverages()
 
   const [sortKey, setSortKey] = useState<SortKey>('indexScore')
   const [sortAsc, setSortAsc] = useState(false)
@@ -238,30 +187,39 @@ function NonProximityPanel({ filters, onSelectSchool }: Pick<FilterResultsProps,
 
   return (
     <div className="bg-white px-4 py-3 h-full">
-      <AveragesBanner filters={filters} schools={schools} countyAvgMap={countyAvgMap} />
-      <div className="flex items-center justify-between mb-2">
-        <p className="text-xs text-gray-500 font-medium">
-{schools.length === 0 ? 'No' : schools.length} {schools.length === 1 ? 'school' : 'schools'} matched
-        </p>
-        <SortBar sortKey={sortKey} sortAsc={sortAsc} options={BASE_OPTIONS} onSortKeyChange={setSortKey} onSortAscChange={setSortAsc} />
-      </div>
-      <div className="flex flex-col gap-3">
-        {sorted.map((school) => (
-          <SchoolCard
-            key={school.id}
-            school={school}
-            countyAvg={schoolDeltaAverage(countyAvgMap, school, filters)}
-            onSelect={onSelectSchool}
-          />
-        ))}
-      </div>
+      {selectedSchool ? (
+        <SchoolComparison school={selectedSchool} onClear={onClearSelection} />
+      ) : (
+        <>
+          <div className="flex items-center justify-between mb-2">
+            <p className="text-xs text-gray-500 font-medium">
+              {schools.length === 0 ? 'No' : schools.length} {schools.length === 1 ? 'school' : 'schools'} matched
+            </p>
+            <SortBar sortKey={sortKey} sortAsc={sortAsc} options={BASE_OPTIONS} onSortKeyChange={setSortKey} onSortAscChange={setSortAsc} />
+          </div>
+          <div className="flex flex-col gap-3">
+            {sorted.map((school) => (
+              <SchoolCard key={school.id} school={school} onSelect={onSelectSchool} />
+            ))}
+          </div>
+        </>
+      )}
     </div>
   )
 }
 
-export default function FilterResults({ filters, onSelectSchool, onZoneResult, onZoneFallback }: FilterResultsProps) {
+export default function FilterResults(props: FilterResultsProps) {
+  const { filters, selectedSchool, onSelectSchool, onClearSelection } = props
+
   if (filters.proximity) {
-    return <ProximityPanel filters={filters} onSelectSchool={onSelectSchool} onZoneResult={onZoneResult} onZoneFallback={onZoneFallback} />
+    return <ProximityPanel {...props} />
   }
-  return <NonProximityPanel filters={filters} onSelectSchool={onSelectSchool} />
+  return (
+    <NonProximityPanel
+      filters={filters}
+      selectedSchool={selectedSchool}
+      onSelectSchool={onSelectSchool}
+      onClearSelection={onClearSelection}
+    />
+  )
 }

--- a/src/components/panel/SchoolCard.tsx
+++ b/src/components/panel/SchoolCard.tsx
@@ -2,23 +2,25 @@
 
 import type { School } from '@/types/school'
 import { getMarkerColor } from '@/utils/markerColors'
-import type { CountyLevelAverages } from '@/utils/countyAverages'
-import { formatDelta, deltaColor } from '@/utils/countyAverages'
 
-// Shared by the county-averages banner so its tiles land in the same columns as the
-// cards below it. The width is fixed rather than content-sized: each grid would
-// otherwise size to its own widest cell and the two would drift out of alignment.
-export const METRIC_GRID_CLASS = 'grid grid-cols-2 gap-x-4 gap-y-1 text-xs shrink-0 w-56'
+// Fixed width rather than content-sized, so the metric columns line up card to card
+// instead of each grid sizing to its own widest cell. Wide enough for "Math Growth - MGP",
+// the longest label, to sit on one line; gap is kept tight so the address column isn't
+// squeezed more than necessary.
+const METRIC_GRID_CLASS = 'grid grid-cols-2 gap-x-1 gap-y-1 text-xs shrink-0 w-64'
 
 interface SchoolCardProps {
   school: School
   distanceMiles?: number | null
-  countyAvg?: CountyLevelAverages | null
   onSelect: (school: School) => void
 }
 
 function pct(val: number | string | null | undefined): string {
   return val != null ? `${val}%` : '—'
+}
+
+function pctile(val: number | null | undefined): string {
+  return val != null ? String(Math.round(val)) : '—'
 }
 
 function getMapsUrl(query: string): string {
@@ -28,22 +30,27 @@ function getMapsUrl(query: string): string {
   return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(query)}`
 }
 
-export default function SchoolCard({ school, distanceMiles, countyAvg, onSelect }: SchoolCardProps) {
-  // NDE only publishes county proficiency, so those are the only deltas we can show.
-  const elaDelta = countyAvg ? formatDelta(typeof school.elaProficient === 'number' ? school.elaProficient : null, countyAvg.elaProficient) : null
-  const mathDelta = countyAvg ? formatDelta(typeof school.mathProficient === 'number' ? school.mathProficient : null, countyAvg.mathProficient) : null
-
+export default function SchoolCard({ school, distanceMiles, onSelect }: SchoolCardProps) {
   return (
     <button
       onClick={() => onSelect(school)}
       className="rounded-lg border border-gray-200 p-3 bg-white text-left hover:border-blue-400 hover:shadow-sm transition-colors"
     >
       {/* Title row */}
-      <div className="flex items-baseline gap-2 mb-1">
-        <p className="font-semibold text-gray-900 text-sm leading-tight">{school.name}</p>
+      <div className="flex items-center gap-2 mb-1">
+        <p className="font-semibold text-gray-900 text-sm leading-tight truncate min-w-0">{school.name}</p>
+        <span className="shrink-0 text-xs font-medium" style={{ color: getMarkerColor(school.starRating) }}>
+          {school.starRating !== null ? '★'.repeat(school.starRating) : 'NR'}
+        </span>
         {distanceMiles != null && (
           <span className="text-xs text-gray-400 shrink-0">{distanceMiles.toFixed(1)} mi</span>
         )}
+        <span
+          className="ml-auto shrink-0 text-sm font-bold"
+          style={{ color: getMarkerColor(school.starRating) }}
+        >
+          {Math.trunc(school.indexScore)}
+        </span>
       </div>
 
       {/* Details + metrics */}
@@ -70,28 +77,28 @@ export default function SchoolCard({ school, distanceMiles, countyAvg, onSelect 
         </div>
         <div className={METRIC_GRID_CLASS}>
           <div>
-            <div className="text-gray-400">Stars</div>
-            <div className="font-medium" style={{ color: getMarkerColor(school.starRating) }}>{school.starRating !== null ? '★'.repeat(school.starRating) : 'NR'}</div>
-          </div>
-          <div>
-            <div className="text-gray-400">Score</div>
-            <div className="font-medium">{school.indexScore}</div>
-          </div>
-          <div>
             <div className="text-gray-400">ELA Proficient</div>
-            <div className="font-medium">{pct(school.elaProficient)}{elaDelta && <span className={`ml-1 font-normal ${deltaColor(elaDelta)}`}>({elaDelta}%)</span>}</div>
+            <div className="font-medium">{pct(school.elaProficient)}</div>
           </div>
           <div>
             <div className="text-gray-400">Math Proficient</div>
-            <div className="font-medium">{pct(school.mathProficient)}{mathDelta && <span className={`ml-1 font-normal ${deltaColor(mathDelta)}`}>({mathDelta}%)</span>}</div>
+            <div className="font-medium">{pct(school.mathProficient)}</div>
           </div>
           <div>
-            <div className="text-gray-400">ELA Growth</div>
+            <div className="text-gray-400">ELA Growth - AGP</div>
             <div className="font-medium">{pct(school.elaGrowth)}</div>
           </div>
           <div>
-            <div className="text-gray-400">Math Growth</div>
+            <div className="text-gray-400">Math Growth - AGP</div>
             <div className="font-medium">{pct(school.mathGrowth)}</div>
+          </div>
+          <div>
+            <div className="text-gray-400">ELA Growth - MGP</div>
+            <div className="font-medium">{pctile(school.elaMgp)}</div>
+          </div>
+          <div>
+            <div className="text-gray-400">Math Growth - MGP</div>
+            <div className="font-medium">{pctile(school.mathMgp)}</div>
           </div>
         </div>
       </div>

--- a/src/components/panel/SchoolComparison.tsx
+++ b/src/components/panel/SchoolComparison.tsx
@@ -1,0 +1,250 @@
+'use client'
+
+import type { CSSProperties, ReactNode } from 'react'
+import type { School } from '@/types/school'
+import StarRating from '@/components/StarRating'
+import { getMarkerColor } from '@/utils/markerColors'
+import { useCountyAverages } from '@/hooks/useCountyAverages'
+import { countyAndStateAverages, formatDelta, deltaColor, scopeLabel } from '@/utils/countyAverages'
+
+// The school is the subject: it gets the bar. The county and state are context, drawn as
+// reference marks on the same 0–100% scale. They use different shapes rather than just
+// different colors because Clark's averages sit within a point of the state's — two marks
+// in the same plane would land on top of each other and become one smudge.
+const CAP = 100
+
+// A growth percentile of 50 is the typical Nevada student by construction — the state median is
+// the definition of the scale, not a figure we look up. It is the one reference the growth
+// section can honestly draw, so MGP gets the state caret while the growth percentages get none.
+const MEDIAN_PERCENTILE = 50
+
+function mgpEmptyLabel(school: School): string {
+  return school.level === 'High'
+    ? 'Not reported for high schools'
+    : 'Not reported'
+}
+
+function toNum(val: number | string | null | undefined): number | null {
+  if (val == null || val === '') return null
+  const n = Number(val)
+  return Number.isFinite(n) ? n : null
+}
+
+function pos(val: number): string {
+  return `${Math.max(0, Math.min(CAP, val))}%`
+}
+
+// Proficiency and growth are percentages; MGP is a percentile, which takes no % sign and is
+// published as a whole number.
+type Unit = 'percent' | 'percentile'
+
+function fmt(val: number, unit: Unit = 'percent'): string {
+  return unit === 'percentile' ? String(Math.round(val)) : `${val.toFixed(1)}%`
+}
+
+function StateCaret({ className = '', style, title }: {
+  className?: string
+  style?: CSSProperties
+  title?: string
+}) {
+  return (
+    <span
+      className={`h-0 w-0 border-x-[4px] border-x-transparent border-t-[6px] border-t-gray-500 ${className}`}
+      style={style}
+      title={title}
+    />
+  )
+}
+
+// county/state are null for the growth-percentage metrics — NDE publishes no averages for them,
+// so those bars carry the school's value alone. The bar still earns its place: it puts growth on
+// the same 0–100 scale as proficiency, so the metrics read against each other at a glance.
+function MetricBar({ label, value, county = null, state = null, countyName = null, unit = 'percent', sampleSize = null, emptyLabel = 'Not reported' }: {
+  label: string
+  value: number | null
+  county?: number | null
+  state?: number | null
+  countyName?: string | null
+  unit?: Unit
+  sampleSize?: number | null
+  emptyLabel?: string
+}) {
+  if (value === null) {
+    return (
+      <div>
+        <div className="text-xs font-semibold text-gray-700">{label}</div>
+        <div className="mt-1 text-xs text-gray-400">{emptyLabel}</div>
+      </div>
+    )
+  }
+
+  const countyDelta = county !== null ? formatDelta(value, county) : null
+  const stateDelta = state !== null ? formatDelta(value, state) : null
+  const hasMarks = county !== null || state !== null
+
+  return (
+    <div>
+      <div className="flex items-baseline justify-between gap-2">
+        <span className="text-xs font-semibold text-gray-700">{label}</span>
+        <span className="text-sm font-semibold text-gray-900">{fmt(value, unit)}</span>
+      </div>
+
+      {/* pt-2 reserves the plane above the track for the state caret */}
+      <div className="relative pt-2">
+        {state !== null && (
+          <StateCaret
+            className="absolute top-0 -translate-x-1/2"
+            style={{ left: pos(state) }}
+            title={`Nevada: ${fmt(state, unit)}`}
+          />
+        )}
+        <div className="relative h-4 w-full rounded-sm bg-gray-100">
+          <div
+            className="absolute inset-y-0 left-0 rounded-r bg-blue-600"
+            style={{ width: pos(value) }}
+            title={`This school: ${fmt(value, unit)}`}
+          />
+          {county !== null && (
+            // The 2px white gutters either side are the surface ring — they keep the tick
+            // legible where it crosses the fill without drawing a border on the mark.
+            <div
+              className="absolute -inset-y-0.5 w-1.5 -translate-x-1/2 bg-white px-0.5"
+              style={{ left: pos(county) }}
+              title={`${countyName}: ${fmt(county, unit)}`}
+            >
+              <div className="h-full w-0.5 bg-gray-700" />
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Values live in the key, not on the marks — labelled ticks would collide whenever the
+          county and state averages are close, which for Clark schools is always. With no marks
+          to identify, the key would just restate the value already at the bar's tip. */}
+      {hasMarks && (
+        <div className="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-gray-500">
+          <span className="inline-flex items-center gap-1">
+            <span className="h-2 w-2 rounded-sm bg-blue-600" />
+            This school {fmt(value, unit)}
+          </span>
+          {county !== null && (
+            <span className="inline-flex items-center gap-1">
+              <span className="h-3 w-0.5 bg-gray-700" />
+              {countyName} {fmt(county, unit)}
+            </span>
+          )}
+          {state !== null && (
+            <span className="inline-flex items-center gap-1">
+              <StateCaret />
+              Nevada {fmt(state, unit)}
+            </span>
+          )}
+        </div>
+      )}
+
+      {(countyDelta || stateDelta || sampleSize != null) && (
+        <div className="mt-1 text-[11px]">
+          {countyDelta && (
+            <span className={deltaColor(countyDelta)}>{countyDelta} vs {countyName}</span>
+          )}
+          {countyDelta && stateDelta && <span className="mx-1.5 text-gray-300">·</span>}
+          {stateDelta && <span className={deltaColor(stateDelta)}>{stateDelta} vs Nevada</span>}
+          {(countyDelta || stateDelta) && sampleSize != null && <span className="mx-1.5 text-gray-300">·</span>}
+          {sampleSize != null && (
+            <span className="text-gray-400">{sampleSize.toLocaleString()} students</span>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function Section({ title, children }: {
+  title: string
+  children: ReactNode
+}) {
+  return (
+    <div className="mt-4 first:mt-0">
+      <div className="mb-2 border-b border-gray-100 pb-1 text-[11px] font-semibold uppercase tracking-wide text-gray-400">
+        {title}
+      </div>
+      <div className="flex flex-col gap-4">{children}</div>
+    </div>
+  )
+}
+
+export default function SchoolComparison({ school, onClear }: {
+  school: School
+  onClear: () => void
+}) {
+  const countyAvgMap = useCountyAverages()
+  const { county, state } = countyAndStateAverages(countyAvgMap, school)
+  const countyName = school.county ? scopeLabel(school.county) : null
+
+  return (
+    <div>
+      {/* The chart stands in for the whole results list, so the way back is a back control,
+          not a dismiss ✕ on something sitting above the list. */}
+      <button
+        onClick={onClear}
+        className="mb-3 -ml-1 rounded px-1 py-0.5 text-xs font-medium text-blue-600 hover:bg-blue-50 hover:text-blue-800 transition-colors"
+      >
+        ← Back to results
+      </button>
+
+      <div className="mb-3">
+        <div className="flex items-baseline gap-2">
+          <p className="min-w-0 font-semibold text-gray-900 text-sm leading-tight truncate">{school.name}</p>
+          <span className="shrink-0 text-xs">
+            <StarRating rating={school.starRating} />
+          </span>
+          <span
+            className="ml-auto shrink-0 text-sm font-bold"
+            style={{ color: getMarkerColor(school.starRating) }}
+          >
+            {Math.trunc(school.indexScore)}
+          </span>
+        </div>
+        <p className="text-xs text-gray-500">{school.level} · {school.type}</p>
+      </div>
+
+      <Section title="Proficiency">
+        <MetricBar
+          label="ELA Proficient"
+          value={toNum(school.elaProficient)}
+          county={county?.elaProficient ?? null}
+          state={state?.elaProficient ?? null}
+          countyName={countyName}
+        />
+        <MetricBar
+          label="Math Proficient"
+          value={toNum(school.mathProficient)}
+          county={county?.mathProficient ?? null}
+          state={state?.mathProficient ?? null}
+          countyName={countyName}
+        />
+      </Section>
+
+      <Section title="Growth">
+        <MetricBar label="ELA Growth - AGP" value={toNum(school.elaGrowth)} />
+        <MetricBar
+          label="ELA Growth - MGP"
+          value={school.elaMgp}
+          unit="percentile"
+          state={MEDIAN_PERCENTILE}
+          sampleSize={school.elaMgpN}
+          emptyLabel={mgpEmptyLabel(school)}
+        />
+        <MetricBar label="Math Growth - AGP" value={toNum(school.mathGrowth)} />
+        <MetricBar
+          label="Math Growth - MGP"
+          value={school.mathMgp}
+          unit="percentile"
+          state={MEDIAN_PERCENTILE}
+          sampleSize={school.mathMgpN}
+          emptyLabel={mgpEmptyLabel(school)}
+        />
+      </Section>
+    </div>
+  )
+}

--- a/src/components/table/TableView.tsx
+++ b/src/components/table/TableView.tsx
@@ -2,10 +2,8 @@
 
 import { useState, useMemo, useEffect } from 'react'
 import { useSchools } from '@/hooks/useSchools'
-import { useCountyAverages } from '@/hooks/useCountyAverages'
 import StarRatingComponent from '@/components/StarRating'
 import type { FilterState, School, SchoolWithDistance } from '@/types/school'
-import { schoolDeltaAverage, formatDelta, deltaColor } from '@/utils/countyAverages'
 
 type SortKey = 'name' | 'level' | 'type' | 'starRating' | 'indexScore' | 'elaProficient' | 'mathProficient' | 'elaGrowth' | 'mathGrowth' | 'distanceMiles'
 
@@ -36,7 +34,6 @@ function fmtPct(val: number | string | null | undefined, suffix = '%') {
 
 export default function TableView({ filters, onSelectSchool }: TableViewProps) {
   const { schools, loading, error } = useSchools(filters)
-  const countyAvgMap = useCountyAverages()
   const [sortKey, setSortKey] = useState<SortKey>('indexScore')
   const [sortAsc, setSortAsc] = useState(false)
   const [page, setPage] = useState(0)
@@ -136,11 +133,7 @@ export default function TableView({ filters, onSelectSchool }: TableViewProps) {
                 </td>
               </tr>
             ) : (
-              pageSlice.map((school) => {
-                const countyAvg = schoolDeltaAverage(countyAvgMap, school, filters)
-                const elaDelta = countyAvg ? formatDelta(typeof school.elaProficient === 'number' ? school.elaProficient : null, countyAvg.elaProficient) : null
-                const mathDelta = countyAvg ? formatDelta(typeof school.mathProficient === 'number' ? school.mathProficient : null, countyAvg.mathProficient) : null
-                return (
+              pageSlice.map((school) => (
                 <tr key={school.id} className="group hover:bg-gray-50">
                   <td className="px-4 py-2 font-medium text-gray-900 sticky left-0 z-10 bg-white group-hover:bg-gray-50 shadow-[2px_0_4px_-1px_rgba(0,0,0,0.08)]">
                     {onSelectSchool ? (
@@ -165,17 +158,12 @@ export default function TableView({ filters, onSelectSchool }: TableViewProps) {
                     <StarRatingComponent rating={school.starRating} />
                   </td>
                   <td className="px-4 py-2 w-0 text-gray-700 tabular-nums text-left whitespace-nowrap"><DecimalValue val={school.indexScore} suffix="" /></td>
-                  <td className="px-4 py-2 w-0 text-gray-700 tabular-nums text-left whitespace-nowrap">
-                    {fmtPct(school.elaProficient)}{elaDelta && <span className={`ml-1 font-normal ${deltaColor(elaDelta)}`}>({elaDelta}%)</span>}
-                  </td>
-                  <td className="px-4 py-2 w-0 text-gray-700 tabular-nums text-left whitespace-nowrap">
-                    {fmtPct(school.mathProficient)}{mathDelta && <span className={`ml-1 font-normal ${deltaColor(mathDelta)}`}>({mathDelta}%)</span>}
-                  </td>
+                  <td className="px-4 py-2 w-0 text-gray-700 tabular-nums text-left whitespace-nowrap">{fmtPct(school.elaProficient)}</td>
+                  <td className="px-4 py-2 w-0 text-gray-700 tabular-nums text-left whitespace-nowrap">{fmtPct(school.mathProficient)}</td>
                   <td className="px-4 py-2 w-0 text-gray-700 tabular-nums text-left whitespace-nowrap">{fmtPct(school.elaGrowth)}</td>
                   <td className="px-4 py-2 w-0 text-gray-700 tabular-nums text-left whitespace-nowrap">{fmtPct(school.mathGrowth)}</td>
                 </tr>
-                )
-              })
+              ))
             )}
           </tbody>
         </table>

--- a/src/utils/countyAverages.ts
+++ b/src/utils/countyAverages.ts
@@ -1,4 +1,4 @@
-import type { FilterState, School, SchoolLevel } from '@/types/school'
+import type { School, SchoolLevel } from '@/types/school'
 
 // Official county averages published by NDE (Nevada Report Card), not computed
 // from our own school list -- averaging school-level averages is statistically
@@ -12,29 +12,30 @@ export interface CountyLevelAverages {
   mathProficient: number | null
 }
 
-// Scope used for the statewide figures, which stand in when no county is selected.
+// The key the statewide rows are filed under in the averages data.
 export const STATE_SCOPE = 'State'
 
 export function countyLevelKey(county: string, level: SchoolLevel): string {
   return `${county}:${level}`
 }
 
-// Which average a school's delta is measured against. A proximity search is anchored to
-// a place, not a scope, and its results can straddle a county line -- so each school is
-// compared to its own county. Otherwise the list is exactly the county filter's scope
-// (statewide when there is no filter), and that is what the delta means.
-export function deltaScope(school: School, filters: FilterState): string | null {
-  return filters.proximity ? school.county : filters.county ?? STATE_SCOPE
+// Carson City is an independent city, not a county — "Carson City County" would be wrong.
+export function scopeLabel(scope: string): string {
+  if (scope === STATE_SCOPE) return 'Nevada statewide'
+  return scope === 'Carson City' ? scope : `${scope} County`
 }
 
-export function schoolDeltaAverage(
+// Both scopes a school is charted against. Deliberately independent of the filters: the
+// chart always shows the school's own county and the state, whatever the list is filtered to.
+export function countyAndStateAverages(
   averages: Map<string, CountyLevelAverages> | null,
-  school: School,
-  filters: FilterState
-): CountyLevelAverages | null {
-  const scope = deltaScope(school, filters)
-  if (!averages || scope == null) return null
-  return averages.get(countyLevelKey(scope, school.level)) ?? null
+  school: School
+): { county: CountyLevelAverages | null; state: CountyLevelAverages | null } {
+  if (!averages) return { county: null, state: null }
+  return {
+    county: (school.county && averages.get(countyLevelKey(school.county, school.level))) || null,
+    state: averages.get(countyLevelKey(STATE_SCOPE, school.level)) ?? null,
+  }
 }
 
 export function formatDelta(school: number | null, countyAvg: number | null): string | null {

--- a/src/utils/filterParams.ts
+++ b/src/utils/filterParams.ts
@@ -5,6 +5,19 @@ const VALID_TYPES = new Set<string>(['District', 'Charter', 'Magnet'])
 const VALID_LEVELS = new Set<string>(['Elementary', 'Middle', 'High'])
 const VALID_STARS = new Set<number>([1, 2, 3, 4, 5])
 
+// Whether the user has narrowed the list at all. Gates the results panel, which without a
+// filter would be a card for every school in Nevada.
+export function hasActiveFilters(filters: FilterState): boolean {
+  return (
+    filters.search !== '' ||
+    filters.schoolTypes.length > 0 ||
+    filters.schoolLevels.length > 0 ||
+    filters.starRatings.length > 0 ||
+    filters.county !== null ||
+    filters.proximity !== null
+  )
+}
+
 export function serializeFilters(filters: FilterState): URLSearchParams {
   const params = new URLSearchParams()
 


### PR DESCRIPTION
## Summary
- Replaces inline county-average delta badges on cards/map popups with a dedicated school comparison panel (proficiency + growth bars benchmarked against county/state averages)
- Surfaces Nevada's Median Growth Percentile (MGP) alongside the existing AGP-based growth metric on cards, map markers, and the comparison panel, relabeled "Growth - AGP" / "Growth - MGP" for clarity
- Updates the About page copy to explain the AGP vs. MGP distinction
- Reworks card/marker headers to lead with school name, star rating, and index score

## Test plan
- [ ] `npm run dev`, confirm cards and map popups show the relabeled AGP/MGP metrics with correct values (and "—" for High schools' MGP)
- [ ] Select a school and confirm the comparison panel renders proficiency + growth bars against county/state benchmarks, with MGP's Nevada-median caret and student-count footer
- [ ] Confirm the About page's Growth Metrics section reads correctly
- [ ] `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)