### PR TITLE
Tighten metric labels, add distance to comparison panel

### DIFF
--- a/src/components/map/SchoolMarker.tsx
+++ b/src/components/map/SchoolMarker.tsx
@@ -37,7 +37,7 @@ export default React.memo(function SchoolMarker({ school, isSelected, onSelect, 
   return (
     <Marker ref={markerRef} position={[school.lat, school.lng]} icon={icon} eventHandlers={{ click: () => onSelect?.(school) }}>
       <Popup>
-        <div className="min-w-[280px]">
+        <div className="min-w-[220px]">
           <div className="flex items-center gap-2 mb-1">
             <p className="font-semibold text-sm truncate min-w-0">{school.name}</p>
             <span className="shrink-0 text-xs font-medium" style={{ color: getMarkerColor(school.starRating) }}>
@@ -65,7 +65,7 @@ export default React.memo(function SchoolMarker({ school, isSelected, onSelect, 
               <span className="block">{school.city}, NV{school.zip ? ` ${school.zip}` : ''}</span>
             </a>
           )}
-          <div className="grid grid-cols-2 gap-x-3 gap-y-1 text-xs mt-0">
+          <div className="grid grid-cols-2 gap-x-0.5 gap-y-1 text-xs mt-0">
             <div>
               <div className="text-gray-400">ELA Proficiency</div>
               <div className="font-medium">{school.elaProficiency != null ? `${school.elaProficiency}%` : '—'}</div>
@@ -75,19 +75,19 @@ export default React.memo(function SchoolMarker({ school, isSelected, onSelect, 
               <div className="font-medium">{school.mathProficiency != null ? `${school.mathProficiency}%` : '—'}</div>
             </div>
             <div>
-              <div className="text-gray-400">ELA Growth - AGP</div>
+              <div className="text-gray-400">ELA % Met AGP</div>
               <div className="font-medium">{school.elaGrowth != null ? `${school.elaGrowth}%` : '—'}</div>
             </div>
             <div>
-              <div className="text-gray-400">Math Growth - AGP</div>
+              <div className="text-gray-400">Math % Met AGP</div>
               <div className="font-medium">{school.mathGrowth != null ? `${school.mathGrowth}%` : '—'}</div>
             </div>
             <div>
-              <div className="text-gray-400">ELA Growth - MGP</div>
+              <div className="text-gray-400">ELA MGP</div>
               <div className="font-medium">{school.elaMgp != null ? formatPercentile(school.elaMgp) : '—'}</div>
             </div>
             <div>
-              <div className="text-gray-400">Math Growth - MGP</div>
+              <div className="text-gray-400">Math MGP</div>
               <div className="font-medium">{school.mathMgp != null ? formatPercentile(school.mathMgp) : '—'}</div>
             </div>
           </div>

--- a/src/components/panel/FilterResults.tsx
+++ b/src/components/panel/FilterResults.tsx
@@ -121,7 +121,11 @@ function ProximityPanel({ filters, selectedSchool, onSelectSchool, onClearSelect
     return (
       <div className="bg-white px-4 py-3 h-full">
         {selectedSchool ? (
-          <SchoolComparison school={selectedSchool} onClear={onClearSelection} />
+          <SchoolComparison
+            school={selectedSchool}
+            distanceMiles={selectedSchool.lat != null && selectedSchool.lng != null ? haversineDistanceMiles(proximity.lat, proximity.lng, selectedSchool.lat, selectedSchool.lng) : null}
+            onClear={onClearSelection}
+          />
         ) : (
           <>
             <p className="text-xs text-gray-500 font-medium mb-2">
@@ -148,7 +152,11 @@ function ProximityPanel({ filters, selectedSchool, onSelectSchool, onClearSelect
   return (
     <div className="bg-white px-4 py-3 h-full">
       {selectedSchool ? (
-        <SchoolComparison school={selectedSchool} onClear={onClearSelection} />
+        <SchoolComparison
+          school={selectedSchool}
+          distanceMiles={selectedSchool.lat != null && selectedSchool.lng != null ? haversineDistanceMiles(proximity.lat, proximity.lng, selectedSchool.lat, selectedSchool.lng) : null}
+          onClear={onClearSelection}
+        />
       ) : (
         <>
           <div className="flex items-center justify-between mb-2">

--- a/src/components/panel/SchoolCard.tsx
+++ b/src/components/panel/SchoolCard.tsx
@@ -3,12 +3,13 @@
 import type { School } from '@/types/school'
 import { getMarkerColor } from '@/utils/markerColors'
 import { formatPercentile } from '@/utils/format'
+import { getMapsUrl } from '@/utils/maps'
 
 // Fixed width rather than content-sized, so the metric columns line up card to card
-// instead of each grid sizing to its own widest cell. Wide enough for "Math Growth - MGP",
-// the longest label, to sit on one line; gap is kept tight so the address column isn't
-// squeezed more than necessary.
-const METRIC_GRID_CLASS = 'grid grid-cols-2 gap-x-1 gap-y-1 text-xs shrink-0 w-64'
+// instead of each grid sizing to its own widest cell. Narrower than the longest label
+// ("Math Proficiency"), which wraps to two lines here — traded for a smaller footprint;
+// gap is kept tight so the address column isn't squeezed more than necessary.
+const METRIC_GRID_CLASS = 'grid grid-cols-2 gap-x-0.5 gap-y-1 text-xs shrink-0 w-52'
 
 interface SchoolCardProps {
   school: School
@@ -22,13 +23,6 @@ function pct(val: number | string | null | undefined): string {
 
 function pctile(val: number | null | undefined): string {
   return val != null ? formatPercentile(val) : '—'
-}
-
-function getMapsUrl(query: string): string {
-  if (/iPad|iPhone|iPod/.test(navigator.userAgent)) {
-    return `maps://?q=${encodeURIComponent(query)}`
-  }
-  return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(query)}`
 }
 
 export default function SchoolCard({ school, distanceMiles, onSelect }: SchoolCardProps) {
@@ -86,19 +80,19 @@ export default function SchoolCard({ school, distanceMiles, onSelect }: SchoolCa
             <div className="font-medium">{pct(school.mathProficiency)}</div>
           </div>
           <div>
-            <div className="text-gray-400">ELA Growth - AGP</div>
+            <div className="text-gray-400">ELA % Met AGP</div>
             <div className="font-medium">{pct(school.elaGrowth)}</div>
           </div>
           <div>
-            <div className="text-gray-400">Math Growth - AGP</div>
+            <div className="text-gray-400">Math % Met AGP</div>
             <div className="font-medium">{pct(school.mathGrowth)}</div>
           </div>
           <div>
-            <div className="text-gray-400">ELA Growth - MGP</div>
+            <div className="text-gray-400">ELA MGP</div>
             <div className="font-medium">{pctile(school.elaMgp)}</div>
           </div>
           <div>
-            <div className="text-gray-400">Math Growth - MGP</div>
+            <div className="text-gray-400">Math MGP</div>
             <div className="font-medium">{pctile(school.mathMgp)}</div>
           </div>
         </div>

--- a/src/components/panel/SchoolComparison.tsx
+++ b/src/components/panel/SchoolComparison.tsx
@@ -8,6 +8,7 @@ import { getMarkerColor } from '@/utils/markerColors'
 import { useCountyAverages } from '@/hooks/useCountyAverages'
 import { countyAndStateAverages, formatDelta, deltaColor, scopeLabel } from '@/utils/countyAverages'
 import { formatPercentile } from '@/utils/format'
+import { getMapsUrl } from '@/utils/maps'
 
 // The school is the subject: it gets the bar. The county and state are context, drawn as
 // reference marks on the same 0–100% scale. They use different shapes rather than just
@@ -217,8 +218,9 @@ function Section({ title, children }: {
   )
 }
 
-export default function SchoolComparison({ school, onClear }: {
+export default function SchoolComparison({ school, distanceMiles, onClear }: {
   school: School
+  distanceMiles?: number | null
   onClear: () => void
 }) {
   const countyAvgMap = useCountyAverages()
@@ -242,6 +244,9 @@ export default function SchoolComparison({ school, onClear }: {
           <span className="shrink-0 text-xs">
             <StarRating rating={school.starRating} />
           </span>
+          {distanceMiles != null && (
+            <span className="text-xs text-gray-400 shrink-0">{distanceMiles.toFixed(1)} mi</span>
+          )}
           <span
             className="ml-auto shrink-0 text-sm font-bold"
             style={{ color: getMarkerColor(school.starRating) }}
@@ -250,6 +255,22 @@ export default function SchoolComparison({ school, onClear }: {
           </span>
         </div>
         <p className="text-xs text-gray-500">{school.level} · {school.type}</p>
+        {school.address && school.city && (
+          <a
+            href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(`${school.name}, ${school.address}, ${school.city}, NV ${school.zip ?? ''}`.trim())}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={(e) => {
+              e.preventDefault()
+              const query = `${school.name}, ${school.address}, ${school.city}, NV ${school.zip ?? ''}`.trim()
+              window.open(getMapsUrl(query), '_blank', 'noopener,noreferrer')
+            }}
+            className="text-xs text-blue-500 hover:underline mt-0.5 inline-block"
+          >
+            <span className="block">{school.address}</span>
+            <span className="block">{school.city}, NV{school.zip ? ` ${school.zip}` : ''}</span>
+          </a>
+        )}
       </div>
 
       <Section title="Proficiency">
@@ -282,7 +303,7 @@ export default function SchoolComparison({ school, onClear }: {
       {school.level !== 'High' && (
         <Section title="Growth">
           <MetricBar
-            label="ELA Growth - % Met AGP"
+            label="ELA % Met AGP"
             value={toNum(school.elaGrowth)}
             tooltip={{
               name: 'Adequate Growth Percentile',
@@ -290,7 +311,7 @@ export default function SchoolComparison({ school, onClear }: {
             }}
           />
           <MetricBar
-            label="ELA Growth - MGP"
+            label="ELA MGP"
             value={school.elaMgp}
             unit="percentile"
             tooltip={{
@@ -299,7 +320,7 @@ export default function SchoolComparison({ school, onClear }: {
             }}
           />
           <MetricBar
-            label="Math Growth - % Met AGP"
+            label="Math % Met AGP"
             value={toNum(school.mathGrowth)}
             tooltip={{
               name: 'Adequate Growth Percentile',
@@ -307,7 +328,7 @@ export default function SchoolComparison({ school, onClear }: {
             }}
           />
           <MetricBar
-            label="Math Growth - MGP"
+            label="Math MGP"
             value={school.mathMgp}
             unit="percentile"
             tooltip={{

--- a/src/utils/maps.ts
+++ b/src/utils/maps.ts
@@ -1,0 +1,6 @@
+export function getMapsUrl(query: string): string {
+  if (/iPad|iPhone|iPod/.test(navigator.userAgent)) {
+    return `maps://?q=${encodeURIComponent(query)}`
+  }
+  return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(query)}`
+}


### PR DESCRIPTION
## Summary
- Shortened growth metric labels ("ELA Growth - AGP" → "ELA % Met AGP", "ELA Growth - MGP" → "ELA MGP") and narrowed the metric grid width in the school card and map marker popup for a tighter layout
- Kept "Proficiency" spelled out in full everywhere, consistent with existing labeling convention
- Added distance and a clickable address/maps link to the school comparison panel, matching what's already shown on the school card (extracted the maps-link logic into `src/utils/maps.ts` so both components share it)

## Test plan
- [ ] `npm run lint` passes
- [ ] School card metric grid reads correctly and doesn't overflow on mobile widths
- [ ] Map marker popup metric grid reads correctly at the narrower width
- [ ] Selecting a school from a proximity/zone search shows distance and address in the comparison panel
- [ ] Selecting a school from a non-proximity search still shows the comparison panel correctly (no distance shown)
- [ ] Address link opens Google Maps (or Apple Maps on iOS) as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)