### PR TITLE
Add shareable deep link to school comparison panel

### DIFF
--- a/src/app/schools/page.tsx
+++ b/src/app/schools/page.tsx
@@ -4,6 +4,7 @@ import { Suspense, useCallback, useEffect, useRef, useState } from 'react'
 import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
 import type { FilterState, School } from '@/types/school'
+import { DEFAULT_FILTERS } from '@/types/school'
 import SchoolSearch from '@/components/filters/SchoolSearch'
 import CountyFilter from '@/components/filters/CountyFilter'
 import LevelFilter from '@/components/filters/LevelFilter'
@@ -17,7 +18,7 @@ import MapView from '@/components/map/MapView'
 import TableView from '@/components/table/TableView'
 import FilterResults from '@/components/panel/FilterResults'
 import SchoolComparison from '@/components/panel/SchoolComparison'
-import { hasActiveFilters, parseFilters, serializeFilters } from '@/utils/filterParams'
+import { hasActiveFilters, parseFilters, parseSchoolIds, serializeFilters, serializeSchoolIds } from '@/utils/filterParams'
 
 // Tailwind's xl breakpoint — the width at which the results panel appears beside the map.
 const DESKTOP_QUERY = '(min-width: 1280px)'
@@ -30,8 +31,30 @@ function HomeContent() {
   const [filters, setFilters] = useState<FilterState>(() => parseFilters(searchParams))
   const [selectedSchool, setSelectedSchool] = useState<School | null>(null)
   const [addressError, setAddressError] = useState<string | null>(null)
+  const [pendingSchoolId] = useState<string | null>(() => parseSchoolIds(searchParams)[0] ?? null)
   const isPopState = useRef(false)
   const mobileListRef = useRef<HTMLDivElement>(null)
+
+  // Unfiltered list, used only to resolve a deep-linked school id (from ?ids=) against — the
+  // "filtered" school list depends on filter state that hasn't necessarily been set to match it.
+  const { schools: allSchools } = useSchools(DEFAULT_FILTERS)
+  const allSchoolsRef = useRef<School[]>(allSchools)
+  allSchoolsRef.current = allSchools
+
+  // Resolves a school id from the URL on first load — once, since selection afterward is driven
+  // by clicks (and popstate, below), not by re-reading the initial searchParams.
+  const resolvedPendingSchool = useRef(false)
+  useEffect(() => {
+    if (resolvedPendingSchool.current || !pendingSchoolId || allSchools.length === 0) return
+    resolvedPendingSchool.current = true
+    const match = allSchools.find((s) => s.id === pendingSchoolId)
+    if (!match) return
+    setSelectedSchool(match)
+    // Mobile's map view has no side panel — only a marker popup — so the comparison panel needs
+    // the list/table view to be visible there. Desktop keeps the map, where the panel already
+    // renders alongside it.
+    setView(window.matchMedia(DESKTOP_QUERY).matches ? 'map' : 'table')
+  }, [pendingSchoolId, allSchools])
 
   // The chart takes the banner's place at the top of the list, so a card tapped further down
   // would swap in a chart the user can't see. Bring it back into view.
@@ -42,7 +65,10 @@ function HomeContent() {
   useEffect(() => {
     function handlePopState() {
       isPopState.current = true
-      setFilters(parseFilters(new URLSearchParams(window.location.search)))
+      const params = new URLSearchParams(window.location.search)
+      setFilters(parseFilters(params))
+      const id = parseSchoolIds(params)[0] ?? null
+      setSelectedSchool(id ? allSchoolsRef.current.find((s) => s.id === id) ?? null : null)
     }
     window.addEventListener('popstate', handlePopState)
     return () => window.removeEventListener('popstate', handlePopState)
@@ -54,12 +80,14 @@ function HomeContent() {
       return
     }
     const params = serializeFilters(filters)
+    const idsParam = serializeSchoolIds(selectedSchool ? [selectedSchool.id] : [])
+    if (idsParam) params.set('ids', idsParam)
     const qs = params.toString()
     const timer = setTimeout(() => {
       router.push(qs ? `/schools?${qs}` : '/schools', { scroll: false })
     }, 300)
     return () => clearTimeout(timer)
-  }, [filters, router])
+  }, [filters, selectedSchool, router])
 
   const handleSelectSchool = useCallback((school: School) => {
     setSelectedSchool(school)

--- a/src/components/panel/SchoolComparison.tsx
+++ b/src/components/panel/SchoolComparison.tsx
@@ -204,6 +204,35 @@ function MetricBar({ label, value, county = null, state = null, countyName = nul
   )
 }
 
+function CopyLinkButton({ school }: { school: School }) {
+  const [copied, setCopied] = useState(false)
+
+  return (
+    <button
+      type="button"
+      onClick={async () => {
+        const url = new URL(window.location.href)
+        url.searchParams.set('ids', school.id)
+        // Set directly rather than relying on the debounced address-bar sync to have already run
+        // — the link is correct even if copied immediately after selecting the school.
+        if (school.county) url.searchParams.set('county', school.county)
+        else url.searchParams.delete('county')
+        url.searchParams.set('levels', school.level)
+        try {
+          await navigator.clipboard.writeText(url.toString())
+          setCopied(true)
+          setTimeout(() => setCopied(false), 1500)
+        } catch {
+          // Clipboard unavailable (permissions, insecure context) — nothing more to do.
+        }
+      }}
+      className="shrink-0 rounded px-1 py-0.5 text-xs font-medium text-blue-600 hover:bg-blue-50 hover:text-blue-800 transition-colors"
+    >
+      {copied ? 'Copied!' : 'Copy link'}
+    </button>
+  )
+}
+
 function Section({ title, children }: {
   title: string
   children: ReactNode
@@ -231,12 +260,15 @@ export default function SchoolComparison({ school, distanceMiles, onClear }: {
     <div>
       {/* The chart stands in for the whole results list, so the way back is a back control,
           not a dismiss ✕ on something sitting above the list. */}
-      <button
-        onClick={onClear}
-        className="mb-3 -ml-1 rounded px-1 py-0.5 text-xs font-medium text-blue-600 hover:bg-blue-50 hover:text-blue-800 transition-colors"
-      >
-        ← Back to results
-      </button>
+      <div className="mb-3 -ml-1 flex items-center justify-between">
+        <button
+          onClick={onClear}
+          className="rounded px-1 py-0.5 text-xs font-medium text-blue-600 hover:bg-blue-50 hover:text-blue-800 transition-colors"
+        >
+          ← Back to results
+        </button>
+        <CopyLinkButton school={school} />
+      </div>
 
       <div className="mb-3">
         <div className="flex items-baseline gap-2">

--- a/src/utils/filterParams.ts
+++ b/src/utils/filterParams.ts
@@ -81,3 +81,15 @@ export function parseFilters(params: URLSearchParams): FilterState {
     proximity,
   }
 }
+
+// A separate top-level param rather than part of FilterState — selection isn't a filter. Written
+// as a comma-separated list (like types/levels/stars) so a future multi-school comparison mode
+// can reuse the same URL contract without a rename; today exactly one id is ever selected.
+export function serializeSchoolIds(ids: string[]): string | null {
+  return ids.length ? ids.join(',') : null
+}
+
+export function parseSchoolIds(params: URLSearchParams): string[] {
+  const raw = params.get('ids')
+  return raw ? raw.split(',').filter(Boolean) : []
+}


### PR DESCRIPTION
## Summary
- Selecting a school now syncs a `?ids=<id>` param into the URL, so `/schools?ids=<id>` opens directly to that school's comparison panel on load (desktop map side-panel or mobile list view, whichever shows the panel at that breakpoint)
- Browser back/forward correctly restores/clears the selected school along with filters
- Added a "Copy link" button on the panel that copies a URL scoped to the school's own county and level (for a more useful "back to results" list), without rewriting the visible address bar
- `ids` is a comma-separated param (matching the existing `types`/`levels`/`stars` convention) so a future multi-school comparison mode can reuse the same URL contract without a rename

## Test plan
- [ ] `npm run dev`, select a school on the map/table, confirm the URL updates to `?ids=<id>`
- [ ] Click "Copy link" and confirm the clipboard contents include `ids`, `county`, and `levels` matching the selected school
- [ ] Load `/schools?ids=<id>` directly at a desktop width — panel appears beside the map, flown to the marker
- [ ] Same at a mobile viewport — lands in list/table view with the comparison panel shown
- [ ] Load `/schools?ids=<bad-id>` — falls back gracefully to the normal unselected view
- [ ] Select a school, hit browser back — panel closes and `ids` is removed from the URL; forward re-opens it
- [ ] `npm run lint` && `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)