### PR TITLE
Add side-by-side school comparison mode

### DIFF
--- a/src/app/schools/page.tsx
+++ b/src/app/schools/page.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import { Suspense, useCallback, useEffect, useRef, useState } from 'react'
+import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
-import type { FilterState, School } from '@/types/school'
+import type { FilterState, School, SchoolWithDistance } from '@/types/school'
 import { DEFAULT_FILTERS } from '@/types/school'
 import SchoolSearch from '@/components/filters/SchoolSearch'
 import CountyFilter from '@/components/filters/CountyFilter'
@@ -18,10 +18,16 @@ import MapView from '@/components/map/MapView'
 import TableView from '@/components/table/TableView'
 import FilterResults from '@/components/panel/FilterResults'
 import SchoolComparison from '@/components/panel/SchoolComparison'
+import CompareColumns from '@/components/panel/CompareColumns'
+import CompareTray from '@/components/panel/CompareTray'
 import { hasActiveFilters, parseFilters, parseSchoolIds, serializeFilters, serializeSchoolIds } from '@/utils/filterParams'
+import { haversineDistanceMiles } from '@/utils/haversine'
 
 // Tailwind's xl breakpoint — the width at which the results panel appears beside the map.
 const DESKTOP_QUERY = '(min-width: 1280px)'
+// "2-3 schools" per the comparison feature spec — enough to compare without the table
+// getting unreadable on mobile.
+const MAX_COMPARE = 3
 
 function HomeContent() {
   const router = useRouter()
@@ -32,6 +38,9 @@ function HomeContent() {
   const [selectedSchool, setSelectedSchool] = useState<School | null>(null)
   const [addressError, setAddressError] = useState<string | null>(null)
   const [pendingSchoolId] = useState<string | null>(() => parseSchoolIds(searchParams)[0] ?? null)
+  const [pinnedForCompare, setPinnedForCompare] = useState<School[]>([])
+  const [compareMode, setCompareMode] = useState(false)
+  const [pendingCompareIds] = useState<string[]>(() => parseSchoolIds(searchParams, 'compare'))
   const isPopState = useRef(false)
   const mobileListRef = useRef<HTMLDivElement>(null)
 
@@ -56,6 +65,23 @@ function HomeContent() {
     setView(window.matchMedia(DESKTOP_QUERY).matches ? 'map' : 'table')
   }, [pendingSchoolId, allSchools])
 
+  // Same deep-link pattern as pendingSchoolId above, but for a shared comparison link
+  // (?compare=id1,id2) — resolves once, then opens straight into the compare view (which
+  // covers the whole main area regardless of the map/table toggle) so "look at these two
+  // options" links work without extra clicks.
+  const resolvedPendingCompare = useRef(false)
+  useEffect(() => {
+    if (resolvedPendingCompare.current || pendingCompareIds.length === 0 || allSchools.length === 0) return
+    resolvedPendingCompare.current = true
+    const matches = pendingCompareIds
+      .map((id) => allSchools.find((s) => s.id === id))
+      .filter((s): s is SchoolWithDistance => !!s)
+      .slice(0, MAX_COMPARE)
+    if (matches.length === 0) return
+    setPinnedForCompare(matches)
+    if (matches.length >= 2) setCompareMode(true)
+  }, [pendingCompareIds, allSchools])
+
   // The chart takes the banner's place at the top of the list, so a card tapped further down
   // would swap in a chart the user can't see. Bring it back into view.
   useEffect(() => {
@@ -69,6 +95,12 @@ function HomeContent() {
       setFilters(parseFilters(params))
       const id = parseSchoolIds(params)[0] ?? null
       setSelectedSchool(id ? allSchoolsRef.current.find((s) => s.id === id) ?? null : null)
+      const compareMatches = parseSchoolIds(params, 'compare')
+        .map((cid) => allSchoolsRef.current.find((s) => s.id === cid))
+        .filter((s): s is SchoolWithDistance => !!s)
+        .slice(0, MAX_COMPARE)
+      setPinnedForCompare(compareMatches)
+      setCompareMode(compareMatches.length >= 2)
     }
     window.addEventListener('popstate', handlePopState)
     return () => window.removeEventListener('popstate', handlePopState)
@@ -82,12 +114,20 @@ function HomeContent() {
     const params = serializeFilters(filters)
     const idsParam = serializeSchoolIds(selectedSchool ? [selectedSchool.id] : [])
     if (idsParam) params.set('ids', idsParam)
+    const compareParam = serializeSchoolIds(pinnedForCompare.map((s) => s.id))
+    if (compareParam) params.set('compare', compareParam)
     const qs = params.toString()
     const timer = setTimeout(() => {
       router.push(qs ? `/schools?${qs}` : '/schools', { scroll: false })
     }, 300)
     return () => clearTimeout(timer)
-  }, [filters, selectedSchool, router])
+  }, [filters, selectedSchool, pinnedForCompare, router])
+
+  // Dropping below 2 pinned schools (via the tray's × chips) closes the compare view — the
+  // same way a solo school falls back to browsing.
+  useEffect(() => {
+    if (compareMode && pinnedForCompare.length < 2) setCompareMode(false)
+  }, [compareMode, pinnedForCompare])
 
   const handleSelectSchool = useCallback((school: School) => {
     setSelectedSchool(school)
@@ -99,6 +139,36 @@ function HomeContent() {
   const hasActive = hasActiveFilters(filters)
 
   const clearSelection = useCallback(() => setSelectedSchool(null), [])
+
+  const handleToggleCompare = useCallback((school: School) => {
+    setPinnedForCompare((prev) => {
+      if (prev.some((s) => s.id === school.id)) return prev.filter((s) => s.id !== school.id)
+      if (prev.length >= MAX_COMPARE) return prev
+      return [...prev, school]
+    })
+  }, [])
+
+  const handleRemoveCompare = useCallback((schoolId: string) => {
+    setPinnedForCompare((prev) => prev.filter((s) => s.id !== schoolId))
+  }, [])
+
+  const handleClearCompare = useCallback(() => {
+    setPinnedForCompare([])
+    setCompareMode(false)
+  }, [])
+
+  const handleViewCompare = useCallback(() => setCompareMode(true), [])
+  const handleBackFromCompare = useCallback(() => setCompareMode(false), [])
+
+  const compareIds = useMemo(() => new Set(pinnedForCompare.map((s) => s.id)), [pinnedForCompare])
+  const canAddCompare = pinnedForCompare.length < MAX_COMPARE
+  const showCompareView = compareMode && pinnedForCompare.length >= 2
+
+  const getCompareDistanceMiles = useCallback((school: School) => {
+    const proximity = filters.proximity
+    if (!proximity || school.lat == null || school.lng == null) return null
+    return haversineDistanceMiles(proximity.lat, proximity.lng, school.lat, school.lng)
+  }, [filters.proximity])
 
   const { schools: filteredSchools } = useSchools(filters)
 
@@ -245,14 +315,33 @@ function HomeContent() {
         filters={filters}
         onChange={setFilters}
         onClear={clearFilters}
-        onViewSchools={() => { setView('table'); clearSelection() }}
+        onViewSchools={() => { setView('table'); clearSelection(); handleBackFromCompare() }}
         filterCount={filterCount}
         schoolCount={filteredSchools.length}
       />
 
+      {/* Comparison tray — sits under the filter bar so it's visible from both map and table
+          views. Hidden once the compare view itself is open, since "Back to results" on any
+          column already provides a way out. */}
+      {pinnedForCompare.length > 0 && !compareMode && (
+        <CompareTray
+          schools={pinnedForCompare}
+          onRemove={handleRemoveCompare}
+          onClear={handleClearCompare}
+          onView={handleViewCompare}
+        />
+      )}
+
       {/* Main content */}
       <main className="flex-1 overflow-hidden">
-        <div className={view === 'map' ? 'flex xl:flex-row h-full' : 'hidden'}>
+        {/* Compare view covers the whole main area — the same space the map or table would
+            otherwise fill — rather than being squeezed into the 1/3 side panel. Kept as a
+            CSS-hidden sibling (not conditionally unmounted) so the map underneath keeps its
+            zoom/pan state across compare toggles, matching the existing map/table pattern. */}
+        <div className={showCompareView ? 'h-full' : 'hidden'}>
+          <CompareColumns schools={pinnedForCompare} onExit={handleBackFromCompare} getDistanceMiles={getCompareDistanceMiles} />
+        </div>
+        <div className={!showCompareView && view === 'map' ? 'flex xl:flex-row h-full' : 'hidden'}>
           {(hasActive || selectedSchool) && (
             <div className="hidden xl:block shrink-0 xl:w-1/3 xl:border-r border-gray-200 overflow-y-auto">
               {hasActive ? (
@@ -263,6 +352,9 @@ function HomeContent() {
                   onClearSelection={clearSelection}
                   onZoneResult={(ids) => setFilters((f) => ({ ...f, zonedSchoolIds: ids }))}
                   onZoneFallback={handleZoneFallback}
+                  compareIds={compareIds}
+                  onToggleCompare={handleToggleCompare}
+                  canAddCompare={canAddCompare}
                 />
               ) : selectedSchool && (
                 // Marker clicked on an unfiltered map: the panel opens purely to carry the
@@ -274,13 +366,28 @@ function HomeContent() {
             </div>
           )}
           <div className="flex-1 min-h-0">
-            <MapView filters={filters} selectedSchool={selectedSchool} isVisible={view === 'map'} onSelectSchool={handleSelectSchool} onCountyFilter={(county) => setFilters((f) => ({ ...f, county }))} />
+            <MapView
+              filters={filters}
+              selectedSchool={selectedSchool}
+              isVisible={view === 'map' && !showCompareView}
+              onSelectSchool={handleSelectSchool}
+              onCountyFilter={(county) => setFilters((f) => ({ ...f, county }))}
+              compareIds={compareIds}
+              onToggleCompare={handleToggleCompare}
+              canAddCompare={canAddCompare}
+            />
           </div>
         </div>
-        <div className={view === 'table' ? 'h-full' : 'hidden'}>
+        <div className={!showCompareView && view === 'table' ? 'h-full' : 'hidden'}>
           {/* Desktop: full table */}
           <div className="hidden xl:block h-full">
-            <TableView filters={filters} onSelectSchool={handleSelectSchool} />
+            <TableView
+              filters={filters}
+              onSelectSchool={handleSelectSchool}
+              compareIds={compareIds}
+              onToggleCompare={handleToggleCompare}
+              canAddCompare={canAddCompare}
+            />
           </div>
           {/* Mobile: scrollable card list */}
           <div ref={mobileListRef} className="xl:hidden h-full overflow-y-auto">
@@ -291,6 +398,9 @@ function HomeContent() {
               onClearSelection={clearSelection}
               onZoneResult={(ids) => setFilters((f) => ({ ...f, zonedSchoolIds: ids }))}
               onZoneFallback={handleZoneFallback}
+              compareIds={compareIds}
+              onToggleCompare={handleToggleCompare}
+              canAddCompare={canAddCompare}
             />
           </div>
         </div>

--- a/src/components/map/CountyClusterMarkers.tsx
+++ b/src/components/map/CountyClusterMarkers.tsx
@@ -16,6 +16,9 @@ interface CountyClusterMarkersProps {
   onCountyFilter?: (county: string) => void
   // The selected school's popup is only open while the map is the view on screen — see SchoolMarker.
   isMapVisible?: boolean
+  compareIds?: Set<string>
+  onToggleCompare?: (school: School) => void
+  canAddCompare?: boolean
 }
 
 export default function CountyClusterMarkers({
@@ -25,6 +28,9 @@ export default function CountyClusterMarkers({
   forceIndividual,
   onCountyFilter,
   isMapVisible = true,
+  compareIds,
+  onToggleCompare,
+  canAddCompare = true,
 }: CountyClusterMarkersProps) {
   const map = useMapEvents({
     zoomend: () => setZoom(map.getZoom()),
@@ -64,6 +70,9 @@ export default function CountyClusterMarkers({
             isSelected={selectedSchool?.id === school.id}
             onSelect={onSelectSchool}
             isMapVisible={isMapVisible}
+            isComparing={compareIds?.has(school.id)}
+            onToggleCompare={onToggleCompare}
+            canAddCompare={canAddCompare}
           />
         ))}
       </>

--- a/src/components/map/MapInner.tsx
+++ b/src/components/map/MapInner.tsx
@@ -16,6 +16,9 @@ interface MapInnerProps {
   isVisible?: boolean
   onSelectSchool?: (school: School) => void
   onCountyFilter?: (county: string) => void
+  compareIds?: Set<string>
+  onToggleCompare?: (school: School) => void
+  canAddCompare?: boolean
 }
 
 const NEVADA_CENTER: [number, number] = [38.8, -116.8]
@@ -66,7 +69,7 @@ function CountyFocus({ county }: { county: string | null }) {
   return null
 }
 
-export default function MapInner({ filters, selectedSchool, isVisible, onSelectSchool, onCountyFilter }: MapInnerProps) {
+export default function MapInner({ filters, selectedSchool, isVisible, onSelectSchool, onCountyFilter, compareIds, onToggleCompare, canAddCompare }: MapInnerProps) {
   const { schools, loading, error } = useSchools(filters)
 
   const handleZoneClick = useCallback((schoolId: string) => {
@@ -138,6 +141,9 @@ export default function MapInner({ filters, selectedSchool, isVisible, onSelectS
         forceIndividual={!!filters.county || !!filters.proximity}
         onCountyFilter={onCountyFilter}
         isMapVisible={isVisible ?? true}
+        compareIds={compareIds}
+        onToggleCompare={onToggleCompare}
+        canAddCompare={canAddCompare}
       />
     </MapContainer>
   )

--- a/src/components/map/MapView.tsx
+++ b/src/components/map/MapView.tsx
@@ -16,12 +16,24 @@ interface MapViewProps {
   isVisible?: boolean
   onSelectSchool?: (school: School) => void
   onCountyFilter?: (county: string) => void
+  compareIds?: Set<string>
+  onToggleCompare?: (school: School) => void
+  canAddCompare?: boolean
 }
 
-export default function MapView({ filters, selectedSchool, isVisible, onSelectSchool, onCountyFilter }: MapViewProps) {
+export default function MapView({ filters, selectedSchool, isVisible, onSelectSchool, onCountyFilter, compareIds, onToggleCompare, canAddCompare }: MapViewProps) {
   return (
     <div className="w-full h-full">
-      <MapInner filters={filters} selectedSchool={selectedSchool} isVisible={isVisible} onSelectSchool={onSelectSchool} onCountyFilter={onCountyFilter} />
+      <MapInner
+        filters={filters}
+        selectedSchool={selectedSchool}
+        isVisible={isVisible}
+        onSelectSchool={onSelectSchool}
+        onCountyFilter={onCountyFilter}
+        compareIds={compareIds}
+        onToggleCompare={onToggleCompare}
+        canAddCompare={canAddCompare}
+      />
     </div>
   )
 }

--- a/src/components/map/SchoolMarker.tsx
+++ b/src/components/map/SchoolMarker.tsx
@@ -12,9 +12,12 @@ interface SchoolMarkerProps {
   isSelected?: boolean
   onSelect?: (school: SchoolWithDistance) => void
   isMapVisible?: boolean
+  isComparing?: boolean
+  onToggleCompare?: (school: SchoolWithDistance) => void
+  canAddCompare?: boolean
 }
 
-export default React.memo(function SchoolMarker({ school, isSelected, onSelect, isMapVisible = true }: SchoolMarkerProps) {
+export default React.memo(function SchoolMarker({ school, isSelected, onSelect, isMapVisible = true, isComparing, onToggleCompare, canAddCompare = true }: SchoolMarkerProps) {
   const icon = createMarkerIcon(school.starRating)
   const markerRef = useRef<L.Marker>(null)
 
@@ -91,6 +94,15 @@ export default React.memo(function SchoolMarker({ school, isSelected, onSelect, 
               <div className="font-medium">{school.mathMgp != null ? formatPercentile(school.mathMgp) : '—'}</div>
             </div>
           </div>
+          {onToggleCompare && (
+            <button
+              onClick={() => onToggleCompare(school)}
+              disabled={!isComparing && !canAddCompare}
+              className="mt-2 w-full rounded border px-2 py-1 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-40 border-blue-200 text-blue-600 hover:bg-blue-50 disabled:hover:bg-transparent"
+            >
+              {isComparing ? '✓ Added to Compare' : '+ Add to Compare'}
+            </button>
+          )}
         </div>
       </Popup>
     </Marker>
@@ -100,4 +112,7 @@ export default React.memo(function SchoolMarker({ school, isSelected, onSelect, 
   && prev.isSelected === next.isSelected
   && prev.onSelect === next.onSelect
   && prev.isMapVisible === next.isMapVisible
+  && prev.isComparing === next.isComparing
+  && prev.onToggleCompare === next.onToggleCompare
+  && prev.canAddCompare === next.canAddCompare
 )

--- a/src/components/panel/CompareColumns.tsx
+++ b/src/components/panel/CompareColumns.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import type { School } from '@/types/school'
+import SchoolComparison from './SchoolComparison'
+
+// Reuses the existing single-school detail panel per column rather than a bespoke table —
+// "Back to results" on any column exits compare mode the same way it exits a solo selection,
+// leaving the pinned set intact so the tray can be used to swap schools back in.
+export default function CompareColumns({
+  schools,
+  onExit,
+  getDistanceMiles,
+}: {
+  schools: School[]
+  onExit: () => void
+  getDistanceMiles?: (school: School) => number | null
+}) {
+  return (
+    <div className="flex h-full divide-x divide-gray-200 overflow-x-auto bg-white">
+      {schools.map((school, index) => {
+        // divide-x only borders between existing columns, so with fewer than 3 schools the
+        // last one has no border on its right — leaving the boundary with the blank leftover
+        // third unmarked. Add it explicitly there.
+        const isLastOfFewer = index === schools.length - 1 && schools.length < 3
+        return (
+          <div
+            key={school.id}
+            className={`w-1/3 min-w-[320px] shrink-0 overflow-y-auto px-4 py-3 ${isLastOfFewer ? 'border-r border-gray-200' : ''}`}
+          >
+            <SchoolComparison
+              school={school}
+              distanceMiles={getDistanceMiles ? getDistanceMiles(school) : null}
+              onClear={onExit}
+            />
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/panel/CompareTray.tsx
+++ b/src/components/panel/CompareTray.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import type { School } from '@/types/school'
+
+// Sits under the filter bar, in both map and table views, so a school checked for
+// comparison while browsing the map is still there when the user switches to the table.
+export default function CompareTray({
+  schools,
+  onRemove,
+  onClear,
+  onView,
+}: {
+  schools: School[]
+  onRemove: (schoolId: string) => void
+  onClear: () => void
+  onView: () => void
+}) {
+  const canView = schools.length >= 2
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 border-b border-gray-200 bg-blue-50 px-4 py-2">
+      <span className="shrink-0 text-xs font-semibold text-gray-600">
+        Comparing {schools.length} {schools.length === 1 ? 'school' : 'schools'}:
+      </span>
+      <div className="flex flex-wrap items-center gap-1.5">
+        {schools.map((school) => (
+          <span
+            key={school.id}
+            className="inline-flex max-w-[12rem] items-center gap-1.5 rounded border border-blue-600 bg-blue-600 px-2.5 py-0.5 text-xs font-bold text-white"
+          >
+            <span className="truncate">{school.name}</span>
+            <button
+              onClick={() => onRemove(school.id)}
+              aria-label={`Remove ${school.name} from comparison`}
+              className="shrink-0 text-blue-100 hover:text-white"
+            >
+              ×
+            </button>
+          </span>
+        ))}
+      </div>
+      <div className="ml-auto flex shrink-0 items-center gap-3">
+        {!canView && (
+          <span className="text-xs text-gray-400">Pick at least 1 more to compare</span>
+        )}
+        {canView && (
+          <button
+            onClick={onView}
+            className="rounded border border-blue-600 bg-blue-600 px-2.5 py-0.5 text-xs font-bold text-white transition-colors hover:border-blue-700 hover:bg-blue-700"
+          >
+            View Comparison
+          </button>
+        )}
+        <button
+          onClick={onClear}
+          className="rounded border border-gray-300 bg-white px-2.5 py-0.5 text-xs font-bold text-gray-600 transition-colors hover:border-gray-400"
+        >
+          Clear
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/panel/FilterResults.tsx
+++ b/src/components/panel/FilterResults.tsx
@@ -70,9 +70,22 @@ interface FilterResultsProps {
   onClearSelection: () => void
   onZoneResult: (ids: string[]) => void
   onZoneFallback: () => void
+  compareIds: Set<string>
+  onToggleCompare: (school: School) => void
+  canAddCompare: boolean
 }
 
-function ProximityPanel({ filters, selectedSchool, onSelectSchool, onClearSelection, onZoneResult, onZoneFallback }: FilterResultsProps) {
+function ProximityPanel({
+  filters,
+  selectedSchool,
+  onSelectSchool,
+  onClearSelection,
+  onZoneResult,
+  onZoneFallback,
+  compareIds,
+  onToggleCompare,
+  canAddCompare,
+}: FilterResultsProps) {
   const proximity = filters.proximity!
   const isZone = proximity.radiusMiles === 0
 
@@ -138,6 +151,9 @@ function ProximityPanel({ filters, selectedSchool, onSelectSchool, onClearSelect
                   school={s}
                   distanceMiles={s.lat != null && s.lng != null ? haversineDistanceMiles(proximity.lat, proximity.lng, s.lat, s.lng) : null}
                   onSelect={onSelectSchool}
+                  isComparing={compareIds.has(s.id)}
+                  onToggleCompare={onToggleCompare}
+                  compareDisabled={!canAddCompare}
                 />
               ))}
             </div>
@@ -167,7 +183,15 @@ function ProximityPanel({ filters, selectedSchool, onSelectSchool, onClearSelect
           </div>
           <div className="flex flex-col gap-3">
             {sortedNearby.map((school) => (
-              <SchoolCard key={school.id} school={school} distanceMiles={school.distanceMiles} onSelect={onSelectSchool} />
+              <SchoolCard
+                key={school.id}
+                school={school}
+                distanceMiles={school.distanceMiles}
+                onSelect={onSelectSchool}
+                isComparing={compareIds.has(school.id)}
+                onToggleCompare={onToggleCompare}
+                compareDisabled={!canAddCompare}
+              />
             ))}
           </div>
         </>
@@ -176,7 +200,15 @@ function ProximityPanel({ filters, selectedSchool, onSelectSchool, onClearSelect
   )
 }
 
-function NonProximityPanel({ filters, selectedSchool, onSelectSchool, onClearSelection }: Pick<FilterResultsProps, 'filters' | 'selectedSchool' | 'onSelectSchool' | 'onClearSelection'>) {
+function NonProximityPanel({
+  filters,
+  selectedSchool,
+  onSelectSchool,
+  onClearSelection,
+  compareIds,
+  onToggleCompare,
+  canAddCompare,
+}: Pick<FilterResultsProps, 'filters' | 'selectedSchool' | 'onSelectSchool' | 'onClearSelection' | 'compareIds' | 'onToggleCompare' | 'canAddCompare'>) {
   const { schools, loading } = useSchools(filters)
 
   const [sortKey, setSortKey] = useState<SortKey>('indexScore')
@@ -207,7 +239,14 @@ function NonProximityPanel({ filters, selectedSchool, onSelectSchool, onClearSel
           </div>
           <div className="flex flex-col gap-3">
             {sorted.map((school) => (
-              <SchoolCard key={school.id} school={school} onSelect={onSelectSchool} />
+              <SchoolCard
+                key={school.id}
+                school={school}
+                onSelect={onSelectSchool}
+                isComparing={compareIds.has(school.id)}
+                onToggleCompare={onToggleCompare}
+                compareDisabled={!canAddCompare}
+              />
             ))}
           </div>
         </>
@@ -217,17 +256,8 @@ function NonProximityPanel({ filters, selectedSchool, onSelectSchool, onClearSel
 }
 
 export default function FilterResults(props: FilterResultsProps) {
-  const { filters, selectedSchool, onSelectSchool, onClearSelection } = props
-
-  if (filters.proximity) {
+  if (props.filters.proximity) {
     return <ProximityPanel {...props} />
   }
-  return (
-    <NonProximityPanel
-      filters={filters}
-      selectedSchool={selectedSchool}
-      onSelectSchool={onSelectSchool}
-      onClearSelection={onClearSelection}
-    />
-  )
+  return <NonProximityPanel {...props} />
 }

--- a/src/components/panel/SchoolCard.tsx
+++ b/src/components/panel/SchoolCard.tsx
@@ -15,6 +15,9 @@ interface SchoolCardProps {
   school: School
   distanceMiles?: number | null
   onSelect: (school: School) => void
+  isComparing?: boolean
+  onToggleCompare?: (school: School) => void
+  compareDisabled?: boolean
 }
 
 function pct(val: number | string | null | undefined): string {
@@ -25,7 +28,7 @@ function pctile(val: number | null | undefined): string {
   return val != null ? formatPercentile(val) : '—'
 }
 
-export default function SchoolCard({ school, distanceMiles, onSelect }: SchoolCardProps) {
+export default function SchoolCard({ school, distanceMiles, onSelect, isComparing, onToggleCompare, compareDisabled }: SchoolCardProps) {
   return (
     <button
       onClick={() => onSelect(school)}
@@ -49,8 +52,8 @@ export default function SchoolCard({ school, distanceMiles, onSelect }: SchoolCa
       </div>
 
       {/* Details + metrics */}
-      <div className="flex gap-4 items-start">
-        <div className="flex-1 min-w-0">
+      <div className="flex gap-4 items-stretch">
+        <div className="flex-1 min-w-0 flex flex-col">
           <p className="text-xs text-gray-500">{school.level} · {school.type}</p>
           {school.address && school.city && (
             <a
@@ -68,6 +71,24 @@ export default function SchoolCard({ school, distanceMiles, onSelect }: SchoolCa
               <span className="block">{school.address}</span>
               <span className="block">{school.city}, NV{school.zip ? ` ${school.zip}` : ''}</span>
             </a>
+          )}
+          {onToggleCompare && (
+            <label
+              className={`mt-auto pt-1.5 inline-flex items-center gap-1.5 text-xs ${compareDisabled && !isComparing ? 'text-gray-300' : 'text-gray-500'}`}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <input
+                type="checkbox"
+                checked={!!isComparing}
+                disabled={compareDisabled && !isComparing}
+                onChange={(e) => {
+                  e.stopPropagation()
+                  onToggleCompare(school)
+                }}
+                className="h-3.5 w-3.5 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+              />
+              Compare
+            </label>
           )}
         </div>
         <div className={METRIC_GRID_CLASS}>

--- a/src/components/panel/SchoolComparison.tsx
+++ b/src/components/panel/SchoolComparison.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useRef, useState } from 'react'
-import type { CSSProperties, ReactNode } from 'react'
+import type { ReactNode } from 'react'
 import type { School } from '@/types/school'
 import StarRating from '@/components/StarRating'
 import { getMarkerColor } from '@/utils/markerColors'
@@ -10,10 +10,8 @@ import { countyAndStateAverages, formatDelta, deltaColor, scopeLabel } from '@/u
 import { formatPercentile } from '@/utils/format'
 import { getMapsUrl } from '@/utils/maps'
 
-// The school is the subject: it gets the bar. The county and state are context, drawn as
-// reference marks on the same 0–100% scale. They use different shapes rather than just
-// different colors because Clark's averages sit within a point of the state's — two marks
-// in the same plane would land on top of each other and become one smudge.
+// School, county, and state each get their own bar on the same 0–100% scale, so their
+// literal lengths are directly comparable rather than one bar plus reference marks.
 const CAP = 100
 
 function toNum(val: number | string | null | undefined): number | null {
@@ -85,23 +83,37 @@ function InfoTooltip({ name, description }: TooltipInfo) {
   )
 }
 
-function StateCaret({ className = '', style, title }: {
-  className?: string
-  style?: CSSProperties
-  title?: string
+// Three separate bars (school, county, state) rather than one bar with reference marks —
+// each row is its own literal length, so "how does this school stack up" reads directly off
+// the chart instead of requiring the reader to interpret a tick's position within a fill.
+function Bar({ rowLabel, value, unit, color, title }: {
+  rowLabel: string
+  value: number
+  unit: Unit
+  color: string
+  title: string
 }) {
   return (
-    <span
-      className={`h-0 w-0 border-x-[4px] border-x-transparent border-t-[6px] border-t-gray-500 ${className}`}
-      style={style}
-      title={title}
-    />
+    <div className="flex items-center gap-2">
+      <span className="w-20 shrink-0 truncate text-[11px] text-gray-500" title={rowLabel}>{rowLabel}</span>
+      <div className="relative h-2.5 flex-1 rounded-sm bg-gray-100">
+        <div className={`absolute inset-y-0 left-0 rounded-r ${color}`} style={{ width: pos(value) }} title={title} />
+        {/* Sits right after the fill's edge, on the bar's own line. min() caps how far right
+            it can start so there's always room for the longest label ("100th percentile")
+            before the track's right edge, rather than running off it. */}
+        <span
+          className="absolute top-1/2 -translate-y-1/2 whitespace-nowrap pl-1.5 text-[11px] font-semibold text-gray-900 tabular-nums"
+          style={{ left: `min(${pos(value)}, calc(100% - 7rem))` }}
+        >
+          {fmt(value, unit)}
+        </span>
+      </div>
+    </div>
   )
 }
 
 // county/state are null for the growth-percentage metrics — NDE publishes no averages for them,
-// so those bars carry the school's value alone. The bar still earns its place: it puts growth on
-// the same 0–100 scale as proficiency, so the metrics read against each other at a glance.
+// so those bars carry only the school's row.
 function MetricBar({ label, value, county = null, state = null, countyName = null, unit = 'percent', emptyLabel = 'Not reported', tooltip }: {
   label: string
   value: number | null
@@ -126,70 +138,23 @@ function MetricBar({ label, value, county = null, state = null, countyName = nul
 
   const countyDelta = county !== null ? formatDelta(value, county) : null
   const stateDelta = state !== null ? formatDelta(value, state) : null
-  const hasMarks = county !== null || state !== null
 
   return (
     <div>
-      <div className="flex items-baseline justify-between gap-2">
-        <span className="flex min-w-0 items-center gap-1 text-xs font-semibold text-gray-700">
-          {label}
-          {tooltip && <InfoTooltip {...tooltip} />}
-        </span>
-        <span className="shrink-0 text-sm font-semibold text-gray-900">{fmt(value, unit)}</span>
+      <div className="flex min-w-0 items-center gap-1 text-xs font-semibold text-gray-700">
+        {label}
+        {tooltip && <InfoTooltip {...tooltip} />}
       </div>
 
-      {/* pt-2 reserves the plane above the track for the state caret */}
-      <div className="relative pt-2">
-        {state !== null && (
-          <StateCaret
-            className="absolute top-0 -translate-x-1/2"
-            style={{ left: pos(state) }}
-            title={`Nevada: ${fmt(state, unit)}`}
-          />
+      <div className="mt-1.5 flex flex-col gap-1.5">
+        <Bar rowLabel="This school" value={value} unit={unit} color="bg-blue-600" title={`This school: ${fmt(value, unit)}`} />
+        {county !== null && (
+          <Bar rowLabel={countyName ?? 'County'} value={county} unit={unit} color="bg-gray-500" title={`${countyName}: ${fmt(county, unit)}`} />
         )}
-        <div className="relative h-4 w-full rounded-sm bg-gray-100">
-          <div
-            className="absolute inset-y-0 left-0 rounded-r bg-blue-600"
-            style={{ width: pos(value) }}
-            title={`This school: ${fmt(value, unit)}`}
-          />
-          {county !== null && (
-            // The 2px white gutters either side are the surface ring — they keep the tick
-            // legible where it crosses the fill without drawing a border on the mark.
-            <div
-              className="absolute -inset-y-0.5 w-1.5 -translate-x-1/2 bg-white px-0.5"
-              style={{ left: pos(county) }}
-              title={`${countyName}: ${fmt(county, unit)}`}
-            >
-              <div className="h-full w-0.5 bg-gray-700" />
-            </div>
-          )}
-        </div>
+        {state !== null && (
+          <Bar rowLabel="Nevada" value={state} unit={unit} color="bg-gray-300" title={`Nevada: ${fmt(state, unit)}`} />
+        )}
       </div>
-
-      {/* Values live in the key, not on the marks — labelled ticks would collide whenever the
-          county and state averages are close, which for Clark schools is always. With no marks
-          to identify, the key would just restate the value already at the bar's tip. */}
-      {hasMarks && (
-        <div className="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-gray-500">
-          <span className="inline-flex items-center gap-1">
-            <span className="h-2 w-2 rounded-sm bg-blue-600" />
-            This school {fmt(value, unit)}
-          </span>
-          {county !== null && (
-            <span className="inline-flex items-center gap-1">
-              <span className="h-3 w-0.5 bg-gray-700" />
-              {countyName} {fmt(county, unit)}
-            </span>
-          )}
-          {state !== null && (
-            <span className="inline-flex items-center gap-1">
-              <StateCaret />
-              Nevada {fmt(state, unit)}
-            </span>
-          )}
-        </div>
-      )}
 
       {(countyDelta || stateDelta) && (
         <div className="mt-1 text-[11px]">

--- a/src/components/table/TableView.tsx
+++ b/src/components/table/TableView.tsx
@@ -10,6 +10,9 @@ type SortKey = 'name' | 'level' | 'type' | 'starRating' | 'indexScore' | 'elaPro
 interface TableViewProps {
   filters: FilterState
   onSelectSchool?: (school: School) => void
+  compareIds?: Set<string>
+  onToggleCompare?: (school: School) => void
+  canAddCompare?: boolean
 }
 
 const PAGE_SIZE_OPTIONS = [25, 50, 100, 0] as const // 0 = all
@@ -32,7 +35,7 @@ function fmtPct(val: number | string | null | undefined, suffix = '%') {
   return <DecimalValue val={Number(val)} suffix={suffix} />
 }
 
-export default function TableView({ filters, onSelectSchool }: TableViewProps) {
+export default function TableView({ filters, onSelectSchool, compareIds, onToggleCompare, canAddCompare = true }: TableViewProps) {
   const { schools, loading, error } = useSchools(filters)
   const [sortKey, setSortKey] = useState<SortKey>('indexScore')
   const [sortAsc, setSortAsc] = useState(false)
@@ -40,7 +43,7 @@ export default function TableView({ filters, onSelectSchool }: TableViewProps) {
   const [pageSize, setPageSize] = useState<number>(25)
 
   const hasProximity = filters.proximity !== null
-  const colCount = hasProximity ? 10 : 9
+  const colCount = (hasProximity ? 10 : 9) + (onToggleCompare ? 1 : 0)
 
   // Auto-sort by distance when proximity activates
   useEffect(() => {
@@ -102,6 +105,9 @@ export default function TableView({ filters, onSelectSchool }: TableViewProps) {
               <th className={colClass + ' sticky left-0 z-20 bg-gray-50 shadow-[2px_0_4px_-1px_rgba(0,0,0,0.08)]'} onClick={() => handleSort('name')}>
                 School{indicator('name')}
               </th>
+              {onToggleCompare && (
+                <th className={colClass + ' w-0 cursor-default'}>Compare</th>
+              )}
               {hasProximity && (
                 <th className={colClass + ' w-0 text-right'} onClick={() => handleSort('distanceMiles')}>
                   Distance{indicator('distanceMiles')}
@@ -145,6 +151,18 @@ export default function TableView({ filters, onSelectSchool }: TableViewProps) {
                       </button>
                     ) : <span className="whitespace-nowrap">{school.name}</span>}
                   </td>
+                  {onToggleCompare && (
+                    <td className="px-4 py-2 w-0">
+                      <input
+                        type="checkbox"
+                        checked={!!compareIds?.has(school.id)}
+                        disabled={!canAddCompare && !compareIds?.has(school.id)}
+                        onChange={() => onToggleCompare(school)}
+                        aria-label={`Compare ${school.name}`}
+                        className="h-3.5 w-3.5 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                      />
+                    </td>
+                  )}
                   {hasProximity && (
                     <td className="px-4 py-2 w-0 text-gray-700 tabular-nums text-right">
                       {school.distanceMiles != null

--- a/src/utils/filterParams.ts
+++ b/src/utils/filterParams.ts
@@ -83,13 +83,13 @@ export function parseFilters(params: URLSearchParams): FilterState {
 }
 
 // A separate top-level param rather than part of FilterState — selection isn't a filter. Written
-// as a comma-separated list (like types/levels/stars) so a future multi-school comparison mode
-// can reuse the same URL contract without a rename; today exactly one id is ever selected.
+// as a comma-separated list (like types/levels/stars); the caller decides which URL key it lands
+// under ('ids' for the single viewed-school deep link, 'compare' for the comparison tray).
 export function serializeSchoolIds(ids: string[]): string | null {
   return ids.length ? ids.join(',') : null
 }
 
-export function parseSchoolIds(params: URLSearchParams): string[] {
-  const raw = params.get('ids')
+export function parseSchoolIds(params: URLSearchParams, key = 'ids'): string[] {
+  const raw = params.get(key)
   return raw ? raw.split(',').filter(Boolean) : []
 }


### PR DESCRIPTION
## Summary
- Adds a "Compare" checkbox on school cards, table rows, and map marker popups to pin 2-3 schools without leaving the current view
- A sticky tray under the filter bar tracks pinned schools (chips + "View Comparison"/"Clear"), styled to match the existing filter-pill buttons
- Viewing a comparison reuses the existing single-school detail panel (`SchoolComparison`) laid out side by side in fixed 1/3-width columns, covering the full main content area (the space the map/table normally fill) instead of being squeezed into the sidebar
- Reworked each metric's bar chart to show three separate bars (school, county, state) with the value inline on the bar itself, so magnitudes are directly comparable instead of relying on tick marks
- Shareable via `?compare=id1,id2` deep links, reusing the existing multi-id URL contract

Closes #41

## Test plan
- [ ] `npm run dev`, check the Compare box on 2-3 school cards (map list, table rows, and a map marker popup) and confirm the tray appears with correct chips
- [ ] Click "View Comparison" and confirm the columns render side by side, filling the full main area, with correct metrics per school
- [ ] Confirm a 2-school comparison keeps 1/3-width columns (not 1/2) with a border marking the unused third
- [ ] Confirm "Back to results" returns to the list with the tray still intact, and re-checking a different school allows swapping
- [ ] Copy a comparison link, open in a new tab, confirm it deep-links straight into the compare view
- [ ] `npm run lint` and `npm run build` both pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)