### PR TITLE
Stop writing proximity filters to the URL

### DIFF
--- a/src/components/panel/SchoolComparison.tsx
+++ b/src/components/panel/SchoolComparison.tsx
@@ -183,6 +183,13 @@ function CopyLinkButton({ school }: { school: School }) {
         if (school.county) url.searchParams.set('county', school.county)
         else url.searchParams.delete('county')
         url.searchParams.set('levels', school.level)
+        // Never let a shared link carry the proximity search — it can reveal the sharer's
+        // home/work address. The URL sync effect strips these within ~300ms of any change, but
+        // don't rely on that timing here.
+        url.searchParams.delete('lat')
+        url.searchParams.delete('lng')
+        url.searchParams.delete('radius')
+        url.searchParams.delete('label')
         try {
           await navigator.clipboard.writeText(url.toString())
           setCopied(true)

--- a/src/utils/filterParams.ts
+++ b/src/utils/filterParams.ts
@@ -28,12 +28,9 @@ export function serializeFilters(filters: FilterState): URLSearchParams {
     params.set('stars', filters.starRatings.map(s => (s === null ? '0' : String(s))).join(','))
   }
   if (filters.county) params.set('county', filters.county)
-  if (filters.proximity) {
-    params.set('lat', String(filters.proximity.lat))
-    params.set('lng', String(filters.proximity.lng))
-    params.set('radius', String(filters.proximity.radiusMiles))
-    params.set('label', filters.proximity.label)
-  }
+  // Proximity (lat/lng/radius/label) is deliberately never written to the URL — it can carry a
+  // user's home/work address, and the URL is what gets copied, bookmarked, and logged. It still
+  // gets parsed below for backward compatibility with old links, but never re-serialized.
 
   return params
 }


### PR DESCRIPTION
## Summary
- `serializeFilters` no longer writes `lat`/`lng`/`radius`/`label` into the URL query string — proximity search still filters/sorts results in memory, it just doesn't leak into the address bar, browser history, or shared links.
- `parseFilters` still reads those params (for backward compat with old links); the next debounced URL sync then scrubs them.
- `CopyLinkButton` explicitly strips `lat`/`lng`/`radius`/`label` from the link it builds, as a backstop against the sync's ~300ms debounce window.

## Test plan
- [ ] `npm run dev`, open `/schools`
- [ ] Set an address/proximity filter with a nonzero radius — confirm the URL never picks up `lat`/`lng`/`radius`/`label`
- [ ] Select a school while proximity is active, click "Copy link", paste it — confirm no location params are present
- [ ] Confirm proximity filtering/sorting still works in the map/table/results list
- [ ] Load `/schools?lat=36.17&lng=-115.14&radius=5&label=Test` directly — confirm the filter applies once, then the URL is rewritten to drop those params shortly after

🤖 Generated with [Claude Code](https://claude.com/claude-code)