### PR TITLE
Fix AGP/MGP bar chart label overlapping the fill

### DIFF
--- a/src/components/map/SchoolMarker.tsx
+++ b/src/components/map/SchoolMarker.tsx
@@ -53,7 +53,7 @@ export default React.memo(function SchoolMarker({ school, isSelected, onSelect, 
               className="ml-auto shrink-0 text-sm font-bold"
               style={{ color: getMarkerColor(school.starRating) }}
             >
-              {Math.trunc(school.indexScore)}
+              {school.indexScore.toFixed(1)}
             </span>
           </div>
           <p className="text-xs text-gray-500 mb-1">{school.level} · {school.type}</p>
@@ -98,9 +98,14 @@ export default React.memo(function SchoolMarker({ school, isSelected, onSelect, 
             <button
               onClick={() => onToggleCompare(school)}
               disabled={!isComparing && !canAddCompare}
-              className="mt-2 w-full rounded border px-2 py-1 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-40 border-blue-200 text-blue-600 hover:bg-blue-50 disabled:hover:bg-transparent"
+              className={`mt-2 inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent ${
+                isComparing
+                  ? 'bg-blue-600 text-white border-blue-600'
+                  : 'border-blue-200 text-blue-600 hover:bg-blue-50'
+              }`}
             >
-              {isComparing ? '✓ Added to Compare' : '+ Add to Compare'}
+              <span className="w-2.5 text-center">{isComparing ? '✓' : '+'}</span>
+              Compare
             </button>
           )}
         </div>

--- a/src/components/panel/CompareTray.tsx
+++ b/src/components/panel/CompareTray.tsx
@@ -18,8 +18,8 @@ export default function CompareTray({
   const canView = schools.length >= 2
 
   return (
-    <div className="flex flex-wrap items-center gap-2 border-b border-gray-200 bg-blue-50 px-4 py-2">
-      <span className="shrink-0 text-xs font-semibold text-gray-600">
+    <div className="flex flex-wrap items-center gap-0 border-b border-gray-200 bg-blue-50 px-4 py-2">
+      <span className="w-36 shrink-0 text-xs font-semibold text-gray-600">
         Comparing {schools.length} {schools.length === 1 ? 'school' : 'schools'}:
       </span>
       <div className="flex flex-wrap items-center gap-1.5">

--- a/src/components/panel/SchoolCard.tsx
+++ b/src/components/panel/SchoolCard.tsx
@@ -30,9 +30,16 @@ function pctile(val: number | null | undefined): string {
 
 export default function SchoolCard({ school, distanceMiles, onSelect, isComparing, onToggleCompare, compareDisabled }: SchoolCardProps) {
   return (
-    <button
+    <div
+      role="button"
+      tabIndex={0}
       onClick={() => onSelect(school)}
-      className="rounded-lg border border-gray-200 p-3 bg-white text-left hover:border-blue-400 hover:shadow-sm transition-colors"
+      onKeyDown={(e) => {
+        if (e.key !== 'Enter' && e.key !== ' ') return
+        e.preventDefault()
+        onSelect(school)
+      }}
+      className="cursor-pointer rounded-lg border border-gray-200 p-3 bg-white text-left hover:border-blue-400 hover:shadow-sm transition-colors"
     >
       {/* Title row */}
       <div className="flex items-center gap-2 mb-1">
@@ -47,7 +54,7 @@ export default function SchoolCard({ school, distanceMiles, onSelect, isComparin
           className="ml-auto shrink-0 text-sm font-bold"
           style={{ color: getMarkerColor(school.starRating) }}
         >
-          {Math.trunc(school.indexScore)}
+          {school.indexScore.toFixed(1)}
         </span>
       </div>
 
@@ -73,22 +80,21 @@ export default function SchoolCard({ school, distanceMiles, onSelect, isComparin
             </a>
           )}
           {onToggleCompare && (
-            <label
-              className={`mt-auto pt-1.5 inline-flex items-center gap-1.5 text-xs ${compareDisabled && !isComparing ? 'text-gray-300' : 'text-gray-500'}`}
-              onClick={(e) => e.stopPropagation()}
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                onToggleCompare(school)
+              }}
+              disabled={compareDisabled && !isComparing}
+              className={`mt-auto self-start inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent ${
+                isComparing
+                  ? 'bg-blue-600 text-white border-blue-600'
+                  : 'border-blue-200 text-blue-600 hover:bg-blue-50'
+              }`}
             >
-              <input
-                type="checkbox"
-                checked={!!isComparing}
-                disabled={compareDisabled && !isComparing}
-                onChange={(e) => {
-                  e.stopPropagation()
-                  onToggleCompare(school)
-                }}
-                className="h-3.5 w-3.5 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-              />
+              <span className="w-2.5 text-center">{isComparing ? '✓' : '+'}</span>
               Compare
-            </label>
+            </button>
           )}
         </div>
         <div className={METRIC_GRID_CLASS}>
@@ -118,6 +124,6 @@ export default function SchoolCard({ school, distanceMiles, onSelect, isComparin
           </div>
         </div>
       </div>
-    </button>
+    </div>
   )
 }

--- a/src/components/panel/SchoolComparison.tsx
+++ b/src/components/panel/SchoolComparison.tsx
@@ -274,7 +274,7 @@ export default function SchoolComparison({ school, distanceMiles, onClear }: {
             className="ml-auto shrink-0 text-sm font-bold"
             style={{ color: getMarkerColor(school.starRating) }}
           >
-            {Math.trunc(school.indexScore)}
+            {school.indexScore.toFixed(1)}
           </span>
         </div>
         <p className="text-xs text-gray-500">{school.level} · {school.type}</p>

--- a/src/components/panel/SchoolComparison.tsx
+++ b/src/components/panel/SchoolComparison.tsx
@@ -93,20 +93,39 @@ function Bar({ rowLabel, value, unit, color, title }: {
   color: string
   title: string
 }) {
+  // Below this, the fill is too narrow to hold its own label, so it falls back to dark text
+  // just outside the bar — safe to leave uncapped here since a small fill always leaves plenty
+  // of room to its right, unlike the near-100% case that motivated capping it in the first place.
+  // Percentile text ("40th percentile") is wider than percent text ("20.0%"), so it needs a
+  // higher cutoff before the inside-the-bar treatment has room to work.
+  const smallCutoff = unit === 'percentile' ? 25 : 15
+  const isSmall = value < smallCutoff
+
   return (
-    <div className="flex items-center gap-2">
+    <div className="flex items-center gap-0">
       <span className="w-20 shrink-0 truncate text-[11px] text-gray-500" title={rowLabel}>{rowLabel}</span>
-      <div className="relative h-2.5 flex-1 rounded-sm bg-gray-100">
-        <div className={`absolute inset-y-0 left-0 rounded-r ${color}`} style={{ width: pos(value) }} title={title} />
-        {/* Sits right after the fill's edge, on the bar's own line. min() caps how far right
-            it can start so there's always room for the longest label ("100th percentile")
-            before the track's right edge, rather than running off it. */}
-        <span
-          className="absolute top-1/2 -translate-y-1/2 whitespace-nowrap pl-1.5 text-[11px] font-semibold text-gray-900 tabular-nums"
-          style={{ left: `min(${pos(value)}, calc(100% - 7rem))` }}
-        >
-          {fmt(value, unit)}
-        </span>
+      <div className="relative h-5 flex-1 rounded-sm bg-gray-100">
+        {isSmall ? (
+          <>
+            <div className={`absolute inset-y-0 left-0 rounded-r ${color}`} style={{ width: pos(value) }} title={title} />
+            <span
+              className="absolute top-1/2 -translate-y-1/2 whitespace-nowrap pl-1.5 text-[11px] font-semibold text-gray-900 tabular-nums"
+              style={{ left: pos(value) }}
+            >
+              {fmt(value, unit)}
+            </span>
+          </>
+        ) : (
+          <div
+            className={`absolute inset-y-0 left-0 flex items-center justify-end overflow-visible rounded-r px-1.5 ${color}`}
+            style={{ width: pos(value) }}
+            title={title}
+          >
+            <span className="whitespace-nowrap text-[11px] font-semibold text-white tabular-nums">
+              {fmt(value, unit)}
+            </span>
+          </div>
+        )}
       </div>
     </div>
   )
@@ -149,10 +168,10 @@ function MetricBar({ label, value, county = null, state = null, countyName = nul
       <div className="mt-1.5 flex flex-col gap-1.5">
         <Bar rowLabel="This school" value={value} unit={unit} color="bg-blue-600" title={`This school: ${fmt(value, unit)}`} />
         {county !== null && (
-          <Bar rowLabel={countyName ?? 'County'} value={county} unit={unit} color="bg-gray-500" title={`${countyName}: ${fmt(county, unit)}`} />
+          <Bar rowLabel={countyName ?? 'County'} value={county} unit={unit} color="bg-gray-600" title={`${countyName}: ${fmt(county, unit)}`} />
         )}
         {state !== null && (
-          <Bar rowLabel="Nevada" value={state} unit={unit} color="bg-gray-300" title={`Nevada: ${fmt(state, unit)}`} />
+          <Bar rowLabel="Nevada" value={state} unit={unit} color="bg-gray-500" title={`Nevada: ${fmt(state, unit)}`} />
         )}
       </div>
 

--- a/src/utils/countyAverages.ts
+++ b/src/utils/countyAverages.ts
@@ -19,10 +19,8 @@ export function countyLevelKey(county: string, level: SchoolLevel): string {
   return `${county}:${level}`
 }
 
-// Carson City is an independent city, not a county — "Carson City County" would be wrong.
 export function scopeLabel(scope: string): string {
-  if (scope === STATE_SCOPE) return 'Nevada statewide'
-  return scope === 'Carson City' ? scope : `${scope} County`
+  return scope === STATE_SCOPE ? 'Nevada statewide' : scope
 }
 
 // Both scopes a school is charted against. Deliberately independent of the filters: the


### PR DESCRIPTION
## Summary
- Fixes a bug where the numeric label on the Proficiency/AGP/MGP comparison bars could overlap the colored fill instead of sitting cleanly next to it — this happened for any bar whose value was high enough that the old right-edge cap pulled the label back onto the fill.
- For bars wide enough to contain their own label, the label now renders inside the fill in white text, right-aligned to the fill's edge.
- For short bars (small values), the label falls back to dark text just outside the fill, where there's always room to spare — this path is safe from the original overflow bug since a short fill never gets close to the track's right edge.
- Darkened the county/state reference bar colors slightly so white label text stays readable on them.
- Unifies the "Add to Compare" button's style/behavior between the school card and the map marker popup (compact icon + "Compare" text, fixed width between states, filled background when active).
- Changes the school card's outer element from a `<button>` to a `div[role="button"]` so the compare button and address link are no longer invalid interactive descendants of a button.
- Tightens spacing in the compare tray and fixes its "Comparing N school(s)" label to hold a consistent width.
- Drops the " County" suffix from county names (was overflowing the bar chart's row-label column for longer counties like "White Pine County").

## Test plan
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [ ] Manually verify in the browser: comparison panel bar labels at high/low values, compare button on card + marker in both states, compare tray with 1-3 schools selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)