### PR TITLE
Improve mobile compare UX, group AGP metrics

### DIFF
--- a/src/app/schools/page.tsx
+++ b/src/app/schools/page.tsx
@@ -181,6 +181,7 @@ function HomeContent() {
 
   function clearFilters() {
     setFilters(parseFilters(new URLSearchParams()))
+    handleClearCompare()
   }
 
   const handleZoneFallback = useCallback(() => {

--- a/src/components/panel/CompareColumns.tsx
+++ b/src/components/panel/CompareColumns.tsx
@@ -16,16 +16,20 @@ export default function CompareColumns({
   getDistanceMiles?: (school: School) => number | null
 }) {
   return (
-    <div className="flex h-full divide-x divide-gray-200 overflow-x-auto bg-white">
+    // Below xl the columns can't fit side by side, so they stack and the whole panel scrolls
+    // vertically instead — each column keeps its own overflow-y-auto only at xl, where the
+    // columns sit in a fixed-height row instead of a page-length stack.
+    <div className="flex flex-col xl:flex-row h-full divide-y xl:divide-y-0 xl:divide-x divide-gray-200 overflow-y-auto xl:overflow-y-hidden xl:overflow-x-auto bg-white">
       {schools.map((school, index) => {
         // divide-x only borders between existing columns, so with fewer than 3 schools the
         // last one has no border on its right — leaving the boundary with the blank leftover
-        // third unmarked. Add it explicitly there.
+        // third unmarked. Add it explicitly there. Only relevant at xl since below that the
+        // columns stack full-width and divide-y already borders every gap.
         const isLastOfFewer = index === schools.length - 1 && schools.length < 3
         return (
           <div
             key={school.id}
-            className={`w-1/3 min-w-[320px] shrink-0 overflow-y-auto px-4 py-3 ${isLastOfFewer ? 'border-r border-gray-200' : ''}`}
+            className={`w-full xl:w-1/3 xl:min-w-[320px] shrink-0 xl:overflow-y-auto px-4 py-3 ${isLastOfFewer ? 'xl:border-r border-gray-200' : ''}`}
           >
             <SchoolComparison
               school={school}

--- a/src/components/panel/CompareTray.tsx
+++ b/src/components/panel/CompareTray.tsx
@@ -18,9 +18,11 @@ export default function CompareTray({
   const canView = schools.length >= 2
 
   return (
-    <div className="flex flex-wrap items-center gap-0 border-b border-gray-200 bg-blue-50 px-4 py-2">
-      <span className="w-36 shrink-0 text-xs font-semibold text-gray-600">
-        Comparing {schools.length} {schools.length === 1 ? 'school' : 'schools'}:
+    // Below xl the label, chips, and view/clear buttons are each their own row instead of
+    // fighting for the same line; at xl they rejoin into the original single wrapping row.
+    <div className="flex flex-col gap-2 border-b border-gray-200 bg-blue-50 px-4 py-2 xl:flex-row xl:flex-wrap xl:items-center xl:gap-0">
+      <span className="shrink-0 text-xs font-semibold text-gray-600 xl:w-36">
+        Comparing {schools.length} {schools.length === 1 ? 'school' : 'schools'}
       </span>
       <div className="flex flex-wrap items-center gap-1.5">
         {schools.map((school) => (
@@ -39,7 +41,7 @@ export default function CompareTray({
           </span>
         ))}
       </div>
-      <div className="ml-auto flex shrink-0 items-center gap-3">
+      <div className="flex shrink-0 items-center gap-3 xl:ml-auto">
         {!canView && (
           <span className="text-xs text-gray-400">Pick at least 1 more to compare</span>
         )}

--- a/src/components/panel/SchoolComparison.tsx
+++ b/src/components/panel/SchoolComparison.tsx
@@ -334,20 +334,20 @@ export default function SchoolComparison({ school, distanceMiles, onClear }: {
             }}
           />
           <MetricBar
+            label="Math % Met AGP"
+            value={toNum(school.mathGrowth)}
+            tooltip={{
+              name: 'Adequate Growth Percentile',
+              description: "Each student has their own AGP, a growth target based on reaching or staying proficient. This metric is the percentage of students who met their individual AGP.",
+            }}
+          />
+          <MetricBar
             label="ELA MGP"
             value={school.elaMgp}
             unit="percentile"
             tooltip={{
               name: 'Median Growth Percentile',
               description: "Each student gets a growth percentile from the Nevada Growth Model, based on their year-over-year progress compared to academic peers statewide with similar prior test scores. This metric is the median of those individual percentiles across the school; 50 is typical growth.",
-            }}
-          />
-          <MetricBar
-            label="Math % Met AGP"
-            value={toNum(school.mathGrowth)}
-            tooltip={{
-              name: 'Adequate Growth Percentile',
-              description: "Each student has their own AGP, a growth target based on reaching or staying proficient. This metric is the percentage of students who met their individual AGP.",
             }}
           />
           <MetricBar


### PR DESCRIPTION
## Summary
- "Clear All" now also clears pinned comparisons and exits compare mode
- Compare view stacks vertically and scrolls on mobile instead of side-by-side columns (unchanged at xl+)
- Compare tray's label, school chips, and view/clear buttons each get their own row on mobile instead of wrapping awkwardly
- Reordered the Growth section so both "% Met AGP" bars sit together instead of alternating with MGP

## Test plan
- [ ] On mobile width, pin 2-3 schools and confirm the tray shows label, chips, and buttons as separate rows
- [ ] Open compare view on mobile and confirm columns stack vertically with page scroll
- [ ] Open compare view at desktop width (xl+) and confirm side-by-side columns still work
- [ ] Click "Clear All" with active filters + pinned comparisons and confirm both reset
- [ ] Check a non-High school's Growth section shows AGP bars grouped together

🤖 Generated with [Claude Code](https://claude.com/claude-code)