### PR TITLE
Always-visible CompareTray + filter pill toggles

### DIFF
--- a/src/app/schools/page.tsx
+++ b/src/app/schools/page.tsx
@@ -322,11 +322,10 @@ function HomeContent() {
       {/* Comparison tray — sits under the filter bar so it's visible from both map and list
           views. Hidden once the compare view itself is open, since "Back to results" on any
           column already provides a way out. */}
-      {pinnedForCompare.length > 0 && !compareMode && (
+      {!compareMode && (
         <CompareTray
           schools={pinnedForCompare}
           onRemove={handleRemoveCompare}
-          onClear={handleClearCompare}
           onView={handleViewCompare}
         />
       )}
@@ -366,6 +365,7 @@ function HomeContent() {
           <div className={view === 'map' ? 'flex-1 min-h-0' : 'hidden'}>
             <MapView
               filters={filters}
+              allSchools={allSchools}
               selectedSchool={selectedSchool}
               isVisible={view === 'map' && !showCompareView}
               onSelectSchool={handleSelectSchool}

--- a/src/components/filters/LevelFilter.tsx
+++ b/src/components/filters/LevelFilter.tsx
@@ -25,13 +25,16 @@ export default function LevelFilter({ value, onChange }: LevelFilterProps) {
           <button
             key={level}
             onClick={() => toggle(level)}
-            className={`px-2.5 py-0.5 rounded text-xs font-bold border transition-colors ${
+            className={`inline-flex items-center gap-0.5 px-2 py-0.5 rounded text-xs font-bold border transition-colors ${
               active
                 ? 'bg-blue-600 text-white border-blue-600'
                 : 'bg-white text-gray-600 border-gray-300 hover:border-gray-400'
             }`}
           >
             {level}
+            <span aria-hidden="true" className="inline-block w-2.5 text-center opacity-70">
+              {active ? '×' : '+'}
+            </span>
           </button>
         )
       })}

--- a/src/components/filters/ProximityStatus.tsx
+++ b/src/components/filters/ProximityStatus.tsx
@@ -18,30 +18,33 @@ export default function ProximityStatus({ proximity, county, onChange }: Proximi
     <div className="flex flex-nowrap gap-1 items-center min-w-0">
       <button
         onClick={() => onChange(null)}
-        className="text-xs font-bold border rounded px-2.5 py-0.5 bg-blue-600 text-white border-blue-600 hover:bg-blue-700 transition-colors truncate max-w-40 sm:max-w-xs"
+        className="inline-flex items-center gap-1 text-xs font-bold border rounded px-2.5 py-0.5 bg-blue-600 text-white border-blue-600 hover:bg-blue-700 transition-colors max-w-40 sm:max-w-xs"
       >
-        {proximity.label}
+        <span className="truncate">{proximity.label}</span>
+        <span aria-hidden="true" className="text-blue-100 shrink-0">×</span>
       </button>
-      {([0, 3, 5, 10] as const).map((r) => {
-        const disabled = r === 0 && !zoneAvailable
-        return (
-          <button
-            key={r}
-            onClick={() => onChange({ ...proximity, radiusMiles: r })}
-            disabled={disabled}
-            title={disabled ? 'No school zone data available for this area' : undefined}
-            className={`px-2.5 py-0.5 rounded text-xs font-bold border transition-colors ${
-              disabled
-                ? 'bg-white text-gray-300 border-gray-200 cursor-not-allowed'
-                : proximity.radiusMiles === r
-                  ? 'bg-blue-600 text-white border-blue-600'
-                  : 'bg-white text-gray-600 border-gray-300 hover:border-gray-400'
-            }`}
-          >
-            {r === 0 ? 'Zone' : `${r} mi`}
-          </button>
-        )
-      })}
+      <div className="flex rounded border border-gray-300 overflow-hidden shrink-0">
+        {([0, 3, 5, 10] as const).map((r, i) => {
+          const disabled = r === 0 && !zoneAvailable
+          return (
+            <button
+              key={r}
+              onClick={() => onChange({ ...proximity, radiusMiles: r })}
+              disabled={disabled}
+              title={disabled ? 'No school zone data available for this area' : undefined}
+              className={`px-2.5 py-0.5 text-xs font-bold transition-colors ${i > 0 ? 'border-l border-gray-300' : ''} ${
+                disabled
+                  ? 'bg-white text-gray-300 cursor-not-allowed'
+                  : proximity.radiusMiles === r
+                    ? 'bg-blue-600 text-white'
+                    : 'bg-white text-gray-600 hover:bg-gray-50'
+              }`}
+            >
+              {r === 0 ? 'Zone' : `${r} mi`}
+            </button>
+          )
+        })}
+      </div>
     </div>
   )
 }

--- a/src/components/filters/StarFilter.tsx
+++ b/src/components/filters/StarFilter.tsx
@@ -28,12 +28,15 @@ export default function StarFilter({ value, onChange }: StarFilterProps) {
             key={star ?? 'nr'}
             onClick={() => toggle(star)}
             title={star !== null ? `${star} star${star !== 1 ? 's' : ''}` : 'Not Rated'}
-            className={`w-8 py-0.5 rounded text-xs font-bold border transition-colors ${
+            className={`inline-flex items-center justify-center gap-0.5 w-10 py-0.5 rounded text-xs font-bold border transition-colors ${
               active ? 'text-white border-transparent' : 'bg-white border-gray-300 hover:border-gray-400'
             }`}
             style={active ? { backgroundColor: color, borderColor: color } : { color }}
           >
             {star !== null ? `${star}★` : 'NR'}
+            <span aria-hidden="true" className="inline-block w-2.5 text-center opacity-70">
+              {active ? '×' : '+'}
+            </span>
           </button>
         )
       })}

--- a/src/components/filters/TypeFilter.tsx
+++ b/src/components/filters/TypeFilter.tsx
@@ -25,13 +25,16 @@ export default function TypeFilter({ value, onChange }: TypeFilterProps) {
           <button
             key={type}
             onClick={() => toggle(type)}
-            className={`px-2.5 py-0.5 rounded text-xs font-bold border transition-colors ${
+            className={`inline-flex items-center gap-0.5 px-2 py-0.5 rounded text-xs font-bold border transition-colors ${
               active
                 ? 'bg-blue-600 text-white border-blue-600'
                 : 'bg-white text-gray-600 border-gray-300 hover:border-gray-400'
             }`}
           >
             {type}
+            <span aria-hidden="true" className="inline-block w-2.5 text-center opacity-70">
+              {active ? '×' : '+'}
+            </span>
           </button>
         )
       })}

--- a/src/components/map/MapInner.tsx
+++ b/src/components/map/MapInner.tsx
@@ -2,16 +2,18 @@
 
 import 'leaflet/dist/leaflet.css'
 import { MapContainer, TileLayer, Marker, Circle, useMap } from 'react-leaflet'
-import { useCallback, useEffect } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 import { useSchools } from '@/hooks/useSchools'
 import { createUserLocationIcon } from '@/utils/markerColors'
 import { COUNTY_VIEWS } from '@/utils/countyViews'
+import { haversineDistanceMiles } from '@/utils/haversine'
 import type { FilterState, School } from '@/types/school'
 import ZoneBoundaries from './ZoneBoundaries'
 import CountyClusterMarkers from './CountyClusterMarkers'
 
 interface MapInnerProps {
   filters: FilterState
+  allSchools: School[]
   selectedSchool?: School | null
   isVisible?: boolean
   onSelectSchool?: (school: School) => void
@@ -69,14 +71,34 @@ function CountyFocus({ county }: { county: string | null }) {
   return null
 }
 
-export default function MapInner({ filters, selectedSchool, isVisible, onSelectSchool, onCountyFilter, compareIds, onToggleCompare, canAddCompare }: MapInnerProps) {
+export default function MapInner({ filters, allSchools, selectedSchool, isVisible, onSelectSchool, onCountyFilter, compareIds, onToggleCompare, canAddCompare }: MapInnerProps) {
   const { schools, loading, error } = useSchools(filters)
+
+  const isZone = !!filters.proximity && filters.proximity.radiusMiles === 0 && filters.zonedSchoolIds.length > 0
+
+  // Zone mode's "nearby" cards bypass the other filters (they show whichever school is
+  // zoned for the point, regardless of type/level/star/search/county) — the map otherwise
+  // has no equivalent, so a zoned school excluded by an unrelated filter would show a card
+  // but no marker. Merge it back in so the map stays consistent with the cards.
+  const displaySchools = useMemo(() => {
+    if (!isZone) return schools
+    const present = new Set(schools.map((s) => s.id))
+    const missing = allSchools
+      .filter((s) => filters.zonedSchoolIds.includes(s.id) && !present.has(s.id))
+      .map((s) => ({
+        ...s,
+        distanceMiles: s.lat != null && s.lng != null
+          ? haversineDistanceMiles(filters.proximity!.lat, filters.proximity!.lng, s.lat, s.lng)
+          : null,
+      }))
+    return missing.length ? [...schools, ...missing] : schools
+  }, [schools, allSchools, isZone, filters.zonedSchoolIds, filters.proximity])
 
   const handleZoneClick = useCallback((schoolId: string) => {
     if (!onSelectSchool) return
-    const school = schools.find(s => s.id === schoolId)
+    const school = displaySchools.find(s => s.id === schoolId)
     if (school) onSelectSchool(school)
-  }, [schools, onSelectSchool])
+  }, [displaySchools, onSelectSchool])
   const proximity = filters.proximity
 
   if (loading) {
@@ -135,7 +157,7 @@ export default function MapInner({ filters, selectedSchool, isVisible, onSelectS
         <ZoneBoundaries zonedSchoolIds={filters.zonedSchoolIds} selectedSchoolId={selectedSchool?.id ?? null} onZoneClick={handleZoneClick} />
       )}
       <CountyClusterMarkers
-        schools={schools}
+        schools={displaySchools}
         selectedSchool={selectedSchool}
         onSelectSchool={onSelectSchool}
         forceIndividual={!!filters.county || !!filters.proximity}

--- a/src/components/map/MapView.tsx
+++ b/src/components/map/MapView.tsx
@@ -12,6 +12,7 @@ const MapInner = dynamic(() => import('./MapInner'), {
 
 interface MapViewProps {
   filters: FilterState
+  allSchools: School[]
   selectedSchool?: School | null
   isVisible?: boolean
   onSelectSchool?: (school: School) => void
@@ -21,11 +22,12 @@ interface MapViewProps {
   canAddCompare?: boolean
 }
 
-export default function MapView({ filters, selectedSchool, isVisible, onSelectSchool, onCountyFilter, compareIds, onToggleCompare, canAddCompare }: MapViewProps) {
+export default function MapView({ filters, allSchools, selectedSchool, isVisible, onSelectSchool, onCountyFilter, compareIds, onToggleCompare, canAddCompare }: MapViewProps) {
   return (
     <div className="w-full h-full">
       <MapInner
         filters={filters}
+        allSchools={allSchools}
         selectedSchool={selectedSchool}
         isVisible={isVisible}
         onSelectSchool={onSelectSchool}

--- a/src/components/map/SchoolMarker.tsx
+++ b/src/components/map/SchoolMarker.tsx
@@ -98,14 +98,14 @@ export default React.memo(function SchoolMarker({ school, isSelected, onSelect, 
             <button
               onClick={() => onToggleCompare(school)}
               disabled={!isComparing && !canAddCompare}
-              className={`mt-2 inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent ${
+              className={`mt-2 inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-xs font-bold transition-colors disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent ${
                 isComparing
                   ? 'bg-blue-600 text-white border-blue-600'
                   : 'border-blue-200 text-blue-600 hover:bg-blue-50'
               }`}
             >
-              <span className="w-2.5 text-center">{isComparing ? '✓' : '+'}</span>
               Compare
+              <span className="w-2.5 text-center">{isComparing ? '×' : '+'}</span>
             </button>
           )}
         </div>

--- a/src/components/panel/CompareTray.tsx
+++ b/src/components/panel/CompareTray.tsx
@@ -7,29 +7,45 @@ import type { School } from '@/types/school'
 export default function CompareTray({
   schools,
   onRemove,
-  onClear,
   onView,
 }: {
   schools: School[]
   onRemove: (schoolId: string) => void
-  onClear: () => void
   onView: () => void
 }) {
+  const hasSchools = schools.length > 0
   const canView = schools.length >= 2
 
   return (
-    // Below xl, row 1 pairs the label with the view/clear buttons (pinned top-right) and row 2
-    // holds the wrapping chips; at xl everything rejoins into the original single wrapping row
-    // (the label-and-buttons div goes `contents` so its children re-flatten into that row, with
-    // xl:order used to put the chips back between the label and the buttons).
+    // Row 1 (label + view) and row 2 (chips, or an invisible same-sized spacer when empty) are
+    // always both mounted — including when nothing is pinned — so the tray's height never jumps
+    // when the first/last school is added or removed. Below xl they stack; at xl the
+    // label-and-buttons div goes `contents` so its children re-flatten into a single wrapping row
+    // with the chips row (xl:order-2) between the label (xl:order-1) and the view button (xl:order-3).
     <div className="flex flex-col gap-2 border-b border-gray-200 bg-blue-50 px-4 py-2 xl:flex-row xl:flex-wrap xl:items-center xl:gap-0">
       <div className="flex items-center justify-between gap-3 xl:contents">
-        <span className="shrink-0 text-xs font-semibold text-gray-600 xl:w-36">
-          Comparing {schools.length} {schools.length === 1 ? 'school' : 'schools'}
+        <span className={`shrink-0 text-xs font-semibold text-gray-600 ${hasSchools ? 'xl:w-36' : ''}`}>
+          {hasSchools ? (
+            `Comparing ${schools.length} ${schools.length === 1 ? 'school' : 'schools'}`
+          ) : (
+            <>
+              Tap <span className="text-blue-600">Compare</span> on 2 or more schools to see them side by side
+            </>
+          )}
         </span>
         <div className="flex shrink-0 items-center gap-3 xl:order-3 xl:ml-auto">
-          {!canView && (
-            <span className="text-xs text-gray-400">Pick at least 1 more to compare</span>
+          {/* Always exactly one pill-sized element here (rounded border, px-2.5 py-0.5, text-xs) —
+              an invisible spacer, the "pick more" hint, or the button — so this row's height stays
+              the same whether 0, 1, or 2+ schools are pinned. */}
+          {!hasSchools && (
+            <span aria-hidden="true" className="invisible rounded border px-2.5 py-0.5 text-xs font-bold">
+              spacer
+            </span>
+          )}
+          {hasSchools && !canView && (
+            <span className="rounded border border-transparent px-2.5 py-0.5 text-xs text-gray-400">
+              Pick at least 1 more to compare
+            </span>
           )}
           {canView && (
             <button
@@ -39,30 +55,31 @@ export default function CompareTray({
               View Comparison
             </button>
           )}
-          <button
-            onClick={onClear}
-            className="rounded border border-gray-300 bg-white px-2.5 py-0.5 text-xs font-bold text-gray-600 transition-colors hover:border-gray-400"
-          >
-            Clear
-          </button>
         </div>
       </div>
       <div className="flex flex-wrap items-center gap-1.5 xl:order-2">
-        {schools.map((school) => (
-          <span
-            key={school.id}
-            className="inline-flex max-w-[12rem] items-center gap-1.5 rounded border border-blue-600 bg-blue-600 px-2.5 py-0.5 text-xs font-bold text-white"
-          >
-            <span className="truncate">{school.name}</span>
+        {hasSchools ? (
+          schools.map((school) => (
             <button
+              key={school.id}
               onClick={() => onRemove(school.id)}
               aria-label={`Remove ${school.name} from comparison`}
-              className="shrink-0 text-blue-100 hover:text-white"
+              className="inline-flex max-w-[12rem] items-center gap-1.5 rounded border border-blue-600 bg-blue-600 px-2.5 py-0.5 text-xs font-bold text-white transition-colors hover:border-blue-700 hover:bg-blue-700"
             >
-              ×
+              <span className="truncate">{school.name}</span>
+              <span aria-hidden="true" className="shrink-0 text-blue-100">
+                ×
+              </span>
             </button>
+          ))
+        ) : (
+          <span
+            aria-hidden="true"
+            className="invisible inline-flex items-center gap-1.5 rounded border px-2.5 py-0.5 text-xs font-bold"
+          >
+            spacer
           </span>
-        ))}
+        )}
       </div>
     </div>
   )

--- a/src/components/panel/FilterResults.tsx
+++ b/src/components/panel/FilterResults.tsx
@@ -150,9 +150,14 @@ function ProximityPanel({
           />
         ) : (
           <>
-            <p className="text-xs text-gray-500 font-medium mb-2">
-              {zonedSchools.length} {zonedSchools.length === 1 ? 'school' : 'schools'} matched
-            </p>
+            <div className="flex items-center justify-between mb-2">
+              <p className="text-xs text-gray-500 font-medium">
+                {zonedSchools.length} {zonedSchools.length === 1 ? 'school' : 'schools'} matched
+              </p>
+              <div className="invisible">
+                <SortBar sortKey={sortKey} sortAsc={sortAsc} options={BASE_OPTIONS} onSortKeyChange={() => {}} onSortAscChange={() => {}} />
+              </div>
+            </div>
             <div className={CARD_GRID_CLASS}>
               {zonedSchools.map((s) => (
                 <SchoolCard

--- a/src/components/panel/SchoolCard.tsx
+++ b/src/components/panel/SchoolCard.tsx
@@ -86,14 +86,14 @@ export default function SchoolCard({ school, distanceMiles, onSelect, isComparin
                 onToggleCompare(school)
               }}
               disabled={compareDisabled && !isComparing}
-              className={`mt-auto self-start inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent ${
+              className={`mt-auto self-start inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-xs font-bold transition-colors disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent ${
                 isComparing
                   ? 'bg-blue-600 text-white border-blue-600'
                   : 'border-blue-200 text-blue-600 hover:bg-blue-50'
               }`}
             >
-              <span className="w-2.5 text-center">{isComparing ? '✓' : '+'}</span>
               Compare
+              <span className="w-2.5 text-center">{isComparing ? '×' : '+'}</span>
             </button>
           )}
         </div>


### PR DESCRIPTION
## Summary
- CompareTray is now always mounted (whenever compare mode isn't active) instead of only appearing once a school is pinned, with an empty-state hint pointing users at the Compare button; row heights stay constant across 0/1/2+ school states.
- Each comparison pill is now a single clickable button (not just its x), and the redundant Clear button was dropped since View/hint are already mutually exclusive with the empty state.
- Filter pills (Level, Type, Star, Proximity) gained a +/x indicator matching the Compare button's affordance.
- Zone-mode map markers now include zoned schools that other active filters would otherwise exclude, so the map matches the "nearby" cards.

## Test plan
- [ ] `npm run dev`, confirm the CompareTray hint shows with 0 schools selected on both map and list tabs, with no height jump when the 1st/2nd school is added or the last one removed.
- [ ] Tap anywhere on a comparison pill (not just the x) and confirm it removes that school.
- [ ] Add 2+ schools and confirm "View Comparison" opens the compare view.
- [ ] Confirm filter pills (Level/Type/Star/Proximity) show a +/x and still toggle correctly.
- [ ] In zone mode ("Zone" proximity radius) with another filter active, confirm the map still shows the zoned school even if the other filter would otherwise exclude it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)