### PR TITLE
Cull off-screen map markers, CDN tiles for smoother panning

### DIFF
--- a/src/components/map/CountyClusterMarkers.tsx
+++ b/src/components/map/CountyClusterMarkers.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMemo, useState, useCallback } from 'react'
+import { useMemo, useState, useCallback, useRef, useEffect } from 'react'
 import { useMapEvents } from 'react-leaflet'
 import SchoolMarker from './SchoolMarker'
 import CountyPolygons from './CountyPolygons'
@@ -32,12 +32,40 @@ export default function CountyClusterMarkers({
   onToggleCompare,
   canAddCompare = true,
 }: CountyClusterMarkersProps) {
+  const scheduledFrame = useRef<number | null>(null)
+
   const map = useMapEvents({
     zoomend: () => setZoom(map.getZoom()),
+    move: () => {
+      if (scheduledFrame.current != null) return
+      scheduledFrame.current = requestAnimationFrame(() => {
+        scheduledFrame.current = null
+        setBounds(map.getBounds().pad(1))
+      })
+    },
+    moveend: () => {
+      if (scheduledFrame.current != null) {
+        cancelAnimationFrame(scheduledFrame.current)
+        scheduledFrame.current = null
+      }
+      setBounds(map.getBounds().pad(1))
+    },
   })
   const [zoom, setZoom] = useState(map.getZoom())
+  const [bounds, setBounds] = useState(() => map.getBounds().pad(1))
+
+  useEffect(() => {
+    return () => {
+      if (scheduledFrame.current != null) cancelAnimationFrame(scheduledFrame.current)
+    }
+  }, [])
 
   const showIndividual = forceIndividual || zoom >= CLUSTER_ZOOM_THRESHOLD
+
+  const visibleSchools = useMemo(
+    () => schools.filter((school) => school.lat != null && school.lng != null && bounds.contains([school.lat, school.lng])),
+    [schools, bounds]
+  )
 
   const countyGroups = useMemo(() => {
     const groups = new Map<string, SchoolWithDistance[]>()
@@ -63,7 +91,7 @@ export default function CountyClusterMarkers({
   if (showIndividual) {
     return (
       <>
-        {schools.map((school) => (
+        {visibleSchools.map((school) => (
           <SchoolMarker
             key={school.id}
             school={school}

--- a/src/components/map/MapInner.tsx
+++ b/src/components/map/MapInner.tsx
@@ -128,8 +128,8 @@ export default function MapInner({ filters, allSchools, selectedSchool, isVisibl
       style={{ zIndex: 0 }}
     >
       <TileLayer
-        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+        url="https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png"
+        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>'
       />
       <InvalidateOnShow isVisible={isVisible ?? true} />
       {selectedSchool && <FlyToSchool school={selectedSchool} />}

--- a/src/components/panel/CompareTray.tsx
+++ b/src/components/panel/CompareTray.tsx
@@ -24,12 +24,12 @@ export default function CompareTray({
     // with the chips row (xl:order-2) between the label (xl:order-1) and the view button (xl:order-3).
     <div className="flex flex-col gap-2 border-b border-gray-200 bg-blue-50 px-4 py-2 xl:flex-row xl:flex-wrap xl:items-center xl:gap-0">
       <div className="flex items-center justify-between gap-3 xl:contents">
-        <span className={`shrink-0 text-xs font-semibold text-gray-600 ${hasSchools ? 'xl:w-36' : ''}`}>
+        <span className={`xl:shrink-0 text-xs font-semibold text-gray-600 ${hasSchools ? 'xl:w-36' : ''}`}>
           {hasSchools ? (
             `Comparing ${schools.length} ${schools.length === 1 ? 'school' : 'schools'}`
           ) : (
             <>
-              Tap <span className="text-blue-600">Compare</span> on 2 or more schools to see them side by side
+              Tap <span className="text-blue-600">Compare</span> on 2 or more schools
             </>
           )}
         </span>


### PR DESCRIPTION
## Summary
- Only render individual school markers within the current (padded) map viewport instead of every filtered school, drastically cutting DOM/marker count while zoomed in or filtered to a dense county
- Progressively mount markers during a pan (rAF-throttled) instead of only at pan-end, so panning into a new area feels responsive
- Switch map tiles from OSM's rate-limited public server to CARTO's CDN-backed Voyager basemap (same visual style, more reliable loading)
- Fix a pre-existing mobile layout bug: `CompareTray`'s help-text label had an unconditional `shrink-0` that, combined with a non-shrinking spacer badge, forced horizontal overflow across the whole page on narrow screens; scoped it to `xl:` and simplified the copy

## Test plan
- [ ] `npm run dev`, open the map view, zoom in past level 9 or filter to a dense county (e.g. Clark) and confirm panning feels smoother than before
- [ ] Confirm markers mount progressively while dragging rather than only after the pan stops
- [ ] Confirm map tiles load from CARTO and render with no visual regression vs. the previous OSM style
- [ ] At a mobile viewport width (e.g. 390px), confirm no horizontal page overflow/scroll, and that the compare-tray help text ("Tap Compare on 2 or more schools") renders on one line
- [ ] Confirm marker selection, popups, and compare-tray +/- toggles still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)